### PR TITLE
Add Magnitude to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ Steel is an open-source browser API purpose-built for AI agents.
 
 | Rank | Agent           | Organization   | WebVoyager Score | Source                                                                                            | Open Source | New | SOTA |
 | ---- | --------------- | -------------- | ---------------- | ------------------------------------------------------------------------------------------------- | ----------- | --- | ---- |
-| 1 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         | Yes | Yes  |
-| 2 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          | Yes |      |
-| 3 | Kura           | Kura          | 87%             | [Source](https://www.trykura.com/benchmarks) | No          | Yes |      |
-| 4 | Skyvern 2.0    | Skyvern       | 85.85%          | [Source](https://blog.skyvern.com/skyvern-2-0-state-of-the-art-web-navigation-with-85-8-on-webvoyager-eval/) | Yes         | Yes |      |
-| 5 | Project Mariner | Google        | 83.5%           | [Source](https://deepmind.google/technologies/project-mariner/) | No          |     |      |
-| 6 | Proxy          | Convergence AI | 82%             | [Source](https://convergence.ai/training-web-agents-with-web-world-models-dec-2024/) | No          |     |      |
-| 7 | Agent-E        | Emergence AI  | 73.1%           | [Source](https://www.emergence.ai/blog/agent-e-sota) | No          |     |      |
-| 8 | Runner H 0.1   | H Company     | 67%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
-| 9 | WILBUR         | Academic Research | 60.6%           | [Source](https://arxiv.org/abs/2404.05902) | No          |     |      |
-| 10 | WebVoyager     | Academic Research | 59.1%           | [Source](https://arxiv.org/abs/2401.13919) | Yes         |     |      |
-| 11 | Computer Use   | Anthropic     | 52%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
+| 1 | Magnitude    | Magnitude   | 93.9%           | [Source](https://github.com/magnitudedev/webvoyager) | Yes         | Yes | Yes  |
+| 2 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         | Yes |     |
+| 3 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          | Yes |      |
+| 4 | Kura           | Kura          | 87%             | [Source](https://www.trykura.com/benchmarks) | No          | Yes |      |
+| 5 | Skyvern 2.0    | Skyvern       | 85.85%          | [Source](https://blog.skyvern.com/skyvern-2-0-state-of-the-art-web-navigation-with-85-8-on-webvoyager-eval/) | Yes         | Yes |      |
+| 6 | Project Mariner | Google        | 83.5%           | [Source](https://deepmind.google/technologies/project-mariner/) | No          |     |      |
+| 7 | Proxy          | Convergence AI | 82%             | [Source](https://convergence.ai/training-web-agents-with-web-world-models-dec-2024/) | No          |     |      |
+| 8 | Agent-E        | Emergence AI  | 73.1%           | [Source](https://www.emergence.ai/blog/agent-e-sota) | No          |     |      |
+| 9 | Runner H 0.1   | H Company     | 67%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
+| 10 | WILBUR         | Academic Research | 60.6%           | [Source](https://arxiv.org/abs/2404.05902) | No          |     |      |
+| 11 | WebVoyager     | Academic Research | 59.1%           | [Source](https://arxiv.org/abs/2401.13919) | Yes         |     |      |
+| 12 | Computer Use   | Anthropic     | 52%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
 
 **Notes:**
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Steel is an open-source browser API purpose-built for AI agents.
 
 | Rank | Agent           | Organization   | WebVoyager Score | Source                                                                                            | Open Source | New | SOTA |
 | ---- | --------------- | -------------- | ---------------- | ------------------------------------------------------------------------------------------------- | ----------- | --- | ---- |
-| 1 | Magnitude    | Magnitude   | 93.9%           | [Source](https://github.com/magnitudedev/webvoyager) | Yes         | Yes | Yes  |
+| 1 | Magnitude    | Magnitude   | 93.9%           | [Source](https://magnitude.run/webvoyager) | Yes         | Yes | Yes  |
 | 2 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         | Yes |     |
 | 3 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          | Yes |      |
 | 4 | Kura           | Kura          | 87%             | [Source](https://www.trykura.com/benchmarks) | No          | Yes |      |

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -16,7 +16,7 @@ export const leaderboardEntries: LeaderboardEntry[] = [
     organization: "Magnitude",
     webVoyager: {
       score: "93.9%",
-      source: "https://github.com/magnitudedev/webvoyager",
+      source: "https://magnitude.run/webvoyager",
     },
     isNew: true,
     github: "https://github.com/magnitudedev/magnitude",

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -12,6 +12,17 @@ export interface LeaderboardEntry {
 
 export const leaderboardEntries: LeaderboardEntry[] = [
   {
+    agent: "Magnitude",
+    organization: "Magnitude",
+    webVoyager: {
+      score: "93.9%",
+      source: "https://github.com/magnitudedev/webvoyager",
+    },
+    isNew: true,
+    github: "https://github.com/magnitudedev/magnitude",
+    homepage: "https://magnitude.run",
+  },
+  {
     agent: "Browser Use",
     organization: "Browser Use",
     webVoyager: {


### PR DESCRIPTION
Magnitude recently achieved SOTA 93.9% on WebVoyager, detailed completely here along with the entire run.

Writeup: https://github.com/magnitudedev/webvoyager
Full run results (also linked in writeup): https://magnitude-webvoyager.vercel.app/

Would love to be added to the leaderboard :)