### PR TITLE
add Aime Browser-USE to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@ Steel is an open-source browser API purpose-built for AI agents.
 | Rank | Agent           | Organization   | WebVoyager Score | Source                                                                                            | Open Source | New | SOTA |
 | ---- | --------------- | -------------- | ---------------- | ------------------------------------------------------------------------------------------------- | ----------- | --- | ---- |
 | 1 | Magnitude    | Magnitude   | 93.9%           | [Source](https://magnitude.run/webvoyager) | Yes         | Yes | Yes  |
-| 2 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         | Yes |     |
-| 3 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          | Yes |      |
-| 4 | Kura           | Kura          | 87%             | [Source](https://www.trykura.com/benchmarks) | No          | Yes |      |
-| 5 | Skyvern 2.0    | Skyvern       | 85.85%          | [Source](https://blog.skyvern.com/skyvern-2-0-state-of-the-art-web-navigation-with-85-8-on-webvoyager-eval/) | Yes         | Yes |      |
-| 6 | Project Mariner | Google        | 83.5%           | [Source](https://deepmind.google/technologies/project-mariner/) | No          |     |      |
-| 7 | Proxy          | Convergence AI | 82%             | [Source](https://convergence.ai/training-web-agents-with-web-world-models-dec-2024/) | No          |     |      |
-| 8 | Agent-E        | Emergence AI  | 73.1%           | [Source](https://www.emergence.ai/blog/agent-e-sota) | No          |     |      |
-| 9 | Runner H 0.1   | H Company     | 67%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
-| 10 | WILBUR         | Academic Research | 60.6%           | [Source](https://arxiv.org/abs/2404.05902) | No          |     |      |
-| 11 | WebVoyager     | Academic Research | 59.1%           | [Source](https://arxiv.org/abs/2401.13919) | Yes         |     |      |
-| 12 | Computer Use   | Anthropic     | 52%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
+| 2 | Aime Browser-USE    | Aime  | 92.34%           | [Source](https://aime-browser-use.github.io/) | No         | Yes |  |
+| 3 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         | Yes |     |
+| 4 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          | Yes |      |
+| 5 | Kura           | Kura          | 87%             | [Source](https://www.trykura.com/benchmarks) | No          | Yes |      |
+| 6 | Skyvern 2.0    | Skyvern       | 85.85%          | [Source](https://blog.skyvern.com/skyvern-2-0-state-of-the-art-web-navigation-with-85-8-on-webvoyager-eval/) | Yes         | Yes |      |
+| 7 | Project Mariner | Google        | 83.5%           | [Source](https://deepmind.google/technologies/project-mariner/) | No          |     |      |
+| 8 | Proxy          | Convergence AI | 82%             | [Source](https://convergence.ai/training-web-agents-with-web-world-models-dec-2024/) | No          |     |      |
+| 9 | Agent-E        | Emergence AI  | 73.1%           | [Source](https://www.emergence.ai/blog/agent-e-sota) | No          |     |      |
+| 10 | Runner H 0.1   | H Company     | 67%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
+| 11 | WILBUR         | Academic Research | 60.6%           | [Source](https://arxiv.org/abs/2404.05902) | No          |     |      |
+| 12 | WebVoyager     | Academic Research | 59.1%           | [Source](https://arxiv.org/abs/2401.13919) | Yes         |     |      |
+| 13 | Computer Use   | Anthropic     | 52%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
 
 **Notes:**
 

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -23,6 +23,17 @@ export const leaderboardEntries: LeaderboardEntry[] = [
     homepage: "https://magnitude.run",
   },
   {
+    agent: "Aime Browser-USE",
+    organization: "Aime",
+    webVoyager: {
+      score: "92.34%",
+      source: "https://aime-browser-use.github.io/",
+    },
+    isNew: true,
+    github: null,
+    homepage: "https://aime-browser-use.github.io/",
+  },
+  {
     agent: "Browser Use",
     organization: "Browser Use",
     webVoyager: {


### PR DESCRIPTION
Hi!

Aime Browser-USE has recently achieved a 92.34% success rate on the WebVoyager benchmark. You can find our detailed report and results here: https://aime-browser-use.github.io/

The Aime technical report can be found in: https://arxiv.org/abs/2507.11988

We would greatly appreciate it if you could update the leaderboard to include our latest results.😆 Thank you!