### PR TITLE
feat(seo): add sitemap, robots.txt, and AI-friendly llms.txt endpoints

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,9 +3,14 @@ import { defineConfig } from "astro/config";
 
 import tailwindcss from "@tailwindcss/vite";
 
+import sitemap from "@astrojs/sitemap";
+
 // https://astro.build/config
 export default defineConfig({
+  site: "https://leaderboard.steel.dev",
   vite: {
     plugins: [tailwindcss()],
   },
+
+  integrations: [sitemap()],
 });

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "update-readme": "tsc -p tsconfig.script.json && node dist/scripts/update-readme.js"
   },
   "dependencies": {
+    "@astrojs/sitemap": "^3.7.1",
     "@tailwindcss/vite": "^4.0.9",
     "astro": "^5.18.0",
     "posthog-js": "^1.225.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/sitemap':
+        specifier: ^3.7.1
+        version: 3.7.1
       '@tailwindcss/vite':
         specifier: ^4.0.9
         version: 4.2.1(vite@6.4.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.31.1))
@@ -75,6 +78,9 @@ packages:
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/sitemap@3.7.1':
+    resolution: {integrity: sha512-IzQqdTeskaMX+QDZCzMuJIp8A8C1vgzMBp/NmHNnadepHYNHcxQdGLQZYfkbd2EbRXUfOS+UDIKx8sKg0oWVdw==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -1038,6 +1044,12 @@ packages:
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
+  '@types/node@24.12.0':
+    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1148,6 +1160,9 @@ packages:
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2599,6 +2614,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   smol-toml@1.6.0:
     resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
     engines: {node: '>= 18'}
@@ -2613,6 +2633,9 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2781,6 +2804,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3027,6 +3053,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -3065,6 +3094,12 @@ snapshots:
   '@astrojs/prism@3.3.0':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/sitemap@3.7.1':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.3.6
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -3777,6 +3812,14 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.12.0':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 20.19.37
+
   '@types/trusted-types@2.0.7':
     optional: true
 
@@ -3912,6 +3955,8 @@ snapshots:
       picomatch: 2.3.1
 
   arg@4.1.3: {}
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -5956,6 +6001,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.12.0
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.5.0
+
   smol-toml@1.6.0: {}
 
   source-map-js@1.2.1: {}
@@ -5966,6 +6018,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  stream-replace-string@2.0.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6161,6 +6215,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6361,5 +6417,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
   zwitch@2.0.4: {}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,28 @@
+# Steel Agent Leaderboard
+
+> A community-maintained leaderboard and benchmark registry for AI agents. Tracks performance across web navigation, coding, desktop control, tool use, research, and general reasoning benchmarks.
+
+Maintained by Steel (https://steel.dev). All data is community-sourced and independently verified where possible. The leaderboard covers 50+ benchmarks and hundreds of agent results.
+
+## Leaderboard
+
+- [WebVoyager Leaderboard](https://leaderboard.steel.dev/index.md): Rankings of web navigation agents on the WebVoyager benchmark, the most widely adopted web agent evaluation.
+
+## Results Index
+
+- [All Results](https://leaderboard.steel.dev/results.md): All agent benchmark results across every tracked benchmark, filterable by category, benchmark, and agent.
+
+## Benchmark Registry
+
+- [Full Registry](https://leaderboard.steel.dev/registry.md): All benchmarks across all categories with descriptions, top agents, scores, and metadata.
+- [Web Navigation](https://leaderboard.steel.dev/registry/web-navigation.md): WebVoyager, WebArena, VisualWebArena, BrowserGym, AssistantBench, and more.
+- [Research](https://leaderboard.steel.dev/registry/research.md): BrowseComp, MMSearch-Plus, and deep research agent benchmarks.
+- [Desktop Control](https://leaderboard.steel.dev/registry/desktop-control.md): OSWorld, AndroidWorld, Windows Agent Arena, macOSWorld, and more.
+- [Coding](https://leaderboard.steel.dev/registry/coding.md): SWE-bench Verified, HumanEval+, MLE-bench, Aider Benchmark, and more.
+- [Tool Use](https://leaderboard.steel.dev/registry/tool-use.md): ToolBench, Tau-bench, MCP Atlas, Gorilla APIBench, and more.
+- [General Reasoning](https://leaderboard.steel.dev/registry/general-reasoning.md): GAIA, ARC-AGI-2, GPQA Diamond, Humanity's Last Exam, and more.
+- [Specialized](https://leaderboard.steel.dev/registry/specialized.md): Sotopia, AgentHarm, MedAgentBench, FORTRESS, and more.
+
+## Optional
+
+- [Full context file](https://leaderboard.steel.dev/llms-full.txt): All leaderboard data, benchmark descriptions, and results in a single markdown file optimized for LLM context.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://leaderboard.steel.dev/sitemap-index.xml
+LLMs: https://leaderboard.steel.dev/llms.txt

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Astro API endpoint serving a markdown version of the main leaderboard page.
+// ABOUTME: Follows the llms.txt spec - accessible at /index.md.
+
+import type { APIRoute } from "astro";
+import { leaderboardEntries } from "../lib/leaderboard";
+
+export const GET: APIRoute = () => {
+  const lines: string[] = [];
+
+  lines.push("# Steel Agent Leaderboard — WebVoyager");
+  lines.push("");
+  lines.push("> Rankings of web navigation agents on the WebVoyager benchmark.");
+  lines.push("> Source: https://leaderboard.steel.dev | Maintained by Steel (https://steel.dev)");
+  lines.push("");
+  lines.push("WebVoyager is the most widely adopted web agent benchmark — 643 tasks across 15 live public websites, evaluated by a GPT-4V judge. It is the de facto standard for comparing commercial and research web agents.");
+  lines.push("");
+  lines.push("| Rank | Agent | Organization | Score | Homepage |");
+  lines.push("|------|-------|--------------|-------|----------|");
+
+  leaderboardEntries.forEach((entry, i) => {
+    lines.push(
+      `| ${i + 1} | ${entry.agent}${entry.isNew ? " ✦" : ""} | ${entry.organization} | ${entry.webVoyager.score} | ${entry.homepage} |`
+    );
+  });
+
+  lines.push("");
+  lines.push("✦ = recently added");
+  lines.push("");
+  lines.push("## See Also");
+  lines.push("");
+  lines.push("- [All benchmark results](https://leaderboard.steel.dev/results.md)");
+  lines.push("- [Benchmark registry](https://leaderboard.steel.dev/registry.md)");
+  lines.push("- [Full context file](https://leaderboard.steel.dev/llms-full.txt)");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/llms-full.txt.ts
+++ b/src/pages/llms-full.txt.ts
@@ -1,0 +1,99 @@
+// ABOUTME: Astro API endpoint generating a full LLM-optimized context file at build time.
+// ABOUTME: Contains all leaderboard entries, benchmark descriptions, and results in markdown.
+
+import type { APIRoute } from "astro";
+import { leaderboardEntries } from "../lib/leaderboard";
+import { benchmarks, benchmarkDomainLabels, categorySlugs, getBenchmarkAnchorId } from "../lib/benchmarks";
+import { indexEntries } from "../lib/index-data";
+
+export const GET: APIRoute = () => {
+  const lines: string[] = [];
+
+  lines.push("# Steel Agent Leaderboard — Full Context");
+  lines.push("");
+  lines.push("> A community-maintained leaderboard and benchmark registry for AI agents.");
+  lines.push("> Source: https://leaderboard.steel.dev | Maintained by Steel (https://steel.dev)");
+  lines.push("");
+
+  // WebVoyager leaderboard
+  lines.push("## WebVoyager Leaderboard");
+  lines.push("");
+  lines.push("The most widely adopted web agent benchmark. 643 tasks across 15 live websites, evaluated by GPT-4V.");
+  lines.push("");
+  lines.push("| Rank | Agent | Organization | Score | Source |");
+  lines.push("|------|-------|--------------|-------|--------|");
+  leaderboardEntries.forEach((entry, i) => {
+    const source = entry.homepage;
+    lines.push(`| ${i + 1} | ${entry.agent} | ${entry.organization} | ${entry.webVoyager.score} | ${source} |`);
+  });
+  lines.push("");
+
+  // Benchmark Registry
+  lines.push("## Benchmark Registry");
+  lines.push("");
+  lines.push(`${benchmarks.length} benchmarks across 7 categories.`);
+  lines.push("");
+
+  const categoriesInOrder = [
+    "WEB NAV", "RESEARCH", "DESKTOP", "CODING", "TOOL USE", "GENERAL", "SPECIALIZED"
+  ] as const;
+
+  for (const cat of categoriesInOrder) {
+    const catBenchmarks = benchmarks.filter((b) => b.category === cat);
+    if (catBenchmarks.length === 0) continue;
+
+    const label = benchmarkDomainLabels[cat];
+    const slug = categorySlugs[cat as keyof typeof categorySlugs];
+    lines.push(`### ${label}`);
+    lines.push("");
+
+    for (const b of catBenchmarks) {
+      const benchSlug = getBenchmarkAnchorId(b.name);
+      lines.push(`#### ${b.name}`);
+      lines.push("");
+      lines.push(b.description);
+      lines.push("");
+      lines.push(`- **Category:** ${label}`);
+      lines.push(`- **Tasks:** ${b.tasks}`);
+      lines.push(`- **Evaluator:** ${b.evaluator}`);
+      lines.push(`- **Top agent:** ${b.topAgent} (${b.topOrg}) — ${b.topScore}`);
+      lines.push(`- **Human baseline:** ${b.human}`);
+      lines.push(`- **Self-hosted:** ${b.selfHosted ? "Yes" : "No"}`);
+      if (b.benchmarkOrg) lines.push(`- **Benchmark org:** ${b.benchmarkOrg}`);
+      lines.push(`- **Paper:** ${b.paper}`);
+      if (b.github) lines.push(`- **GitHub:** ${b.github}`);
+      lines.push(`- **Detail page:** https://leaderboard.steel.dev/registry/benchmarks/${benchSlug}`);
+      lines.push(`- **Category page:** https://leaderboard.steel.dev/registry/${slug}`);
+      lines.push("");
+    }
+  }
+
+  // Full results index
+  lines.push("## All Agent Results");
+  lines.push("");
+  lines.push(`${indexEntries.length} results across all benchmarks.`);
+  lines.push("");
+
+  const benchmarkNames = [...new Set(indexEntries.map((e) => e.benchmark))];
+  for (const benchmarkName of benchmarkNames) {
+    const entries = indexEntries.filter((e) => e.benchmark === benchmarkName);
+    lines.push(`### ${benchmarkName}`);
+    lines.push("");
+    lines.push("| Rank | Agent | Organization | Score | Open Source | Self-Reported |");
+    lines.push("|------|-------|--------------|-------|-------------|---------------|");
+    entries.forEach((entry, i) => {
+      lines.push(
+        `| ${i + 1} | ${entry.agent} | ${entry.organization} | ${entry.score} | ${entry.openSource ? "Yes" : "No"} | ${entry.selfReported ? "Yes" : "No"} |`
+      );
+    });
+    lines.push("");
+  }
+
+  const content = lines.join("\n");
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+};

--- a/src/pages/registry.md.ts
+++ b/src/pages/registry.md.ts
@@ -1,0 +1,55 @@
+// ABOUTME: Astro API endpoint serving a markdown version of the benchmark registry index.
+// ABOUTME: Follows the llms.txt spec - accessible at /registry.md.
+
+import type { APIRoute } from "astro";
+import { benchmarks, benchmarkDomainLabels, categorySlugs, getBenchmarkAnchorId } from "../lib/benchmarks";
+
+export const GET: APIRoute = () => {
+  const lines: string[] = [];
+
+  lines.push("# AI Agent Benchmark Registry");
+  lines.push("");
+  lines.push("> A curated registry of AI agent benchmarks across all major categories.");
+  lines.push("> Source: https://leaderboard.steel.dev/registry | Maintained by Steel (https://steel.dev)");
+  lines.push("");
+  lines.push(`${benchmarks.length} benchmarks across 7 categories.`);
+  lines.push("");
+
+  const categoriesInOrder = [
+    "WEB NAV", "RESEARCH", "DESKTOP", "CODING", "TOOL USE", "GENERAL", "SPECIALIZED"
+  ] as const;
+
+  for (const cat of categoriesInOrder) {
+    const catBenchmarks = benchmarks.filter((b) => b.category === cat);
+    if (catBenchmarks.length === 0) continue;
+
+    const label = benchmarkDomainLabels[cat];
+    const slug = categorySlugs[cat as keyof typeof categorySlugs];
+
+    lines.push(`## ${label}`);
+    lines.push("");
+    lines.push(`[Full category page](https://leaderboard.steel.dev/registry/${slug}.md)`);
+    lines.push("");
+
+    for (const b of catBenchmarks) {
+      const benchSlug = getBenchmarkAnchorId(b.name);
+      lines.push(`### ${b.name}`);
+      lines.push("");
+      lines.push(b.description);
+      lines.push("");
+      lines.push(`- **Top agent:** ${b.topAgent} (${b.topOrg}) — ${b.topScore}`);
+      lines.push(`- **Tasks:** ${b.tasks} | **Evaluator:** ${b.evaluator} | **Human baseline:** ${b.human}`);
+      lines.push(`- **Detail:** https://leaderboard.steel.dev/registry/benchmarks/${benchSlug}.md`);
+      lines.push("");
+    }
+  }
+
+  lines.push("## See Also");
+  lines.push("");
+  lines.push("- [All results](https://leaderboard.steel.dev/results.md)");
+  lines.push("- [Full context file](https://leaderboard.steel.dev/llms-full.txt)");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/registry/[category].md.ts
+++ b/src/pages/registry/[category].md.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Astro API endpoint serving markdown versions of benchmark category pages.
+// ABOUTME: Follows the llms.txt spec - accessible at /registry/[category].md.
+
+import type { GetStaticPaths, APIRoute } from "astro";
+import {
+  benchmarks,
+  benchmarkDomainLabels,
+  categorySlugs,
+  slugToCategory,
+  categoryRouteLabels,
+  getBenchmarkAnchorId,
+} from "../../lib/benchmarks";
+import type { RoutedCategory } from "../../lib/benchmarks";
+
+export const getStaticPaths: GetStaticPaths = () => {
+  return Object.entries(categorySlugs).map(([category, slug]) => ({
+    params: { category: slug },
+    props: { category: category as RoutedCategory },
+  }));
+};
+
+export const GET: APIRoute = ({ params }) => {
+  const slug = params.category as string;
+  const category = slugToCategory[slug] as RoutedCategory;
+  const label = categoryRouteLabels[category];
+  const catBenchmarks = benchmarks.filter((b) => b.category === category);
+
+  const lines: string[] = [];
+
+  lines.push(`# ${label} Benchmarks`);
+  lines.push("");
+  lines.push(`> AI agent benchmarks in the ${label.toLowerCase()} category.`);
+  lines.push(`> Source: https://leaderboard.steel.dev/registry/${slug} | Maintained by Steel (https://steel.dev)`);
+  lines.push("");
+  lines.push(`${catBenchmarks.length} benchmarks in this category.`);
+  lines.push("");
+
+  for (const b of catBenchmarks) {
+    const benchSlug = getBenchmarkAnchorId(b.name);
+
+    lines.push(`## ${b.name}`);
+    lines.push("");
+    lines.push(b.description);
+    lines.push("");
+    lines.push(`- **Top agent:** ${b.topAgent} (${b.topOrg}) — ${b.topScore}`);
+    lines.push(`- **Tasks:** ${b.tasks}`);
+    lines.push(`- **Evaluator:** ${b.evaluator}`);
+    lines.push(`- **Human baseline:** ${b.human}`);
+    lines.push(`- **Self-hosted:** ${b.selfHosted ? "Yes" : "No"}`);
+    if (b.benchmarkOrg) lines.push(`- **Benchmark org:** ${b.benchmarkOrg}`);
+    lines.push(`- **Paper:** ${b.paper}`);
+    if (b.github) lines.push(`- **GitHub:** ${b.github}`);
+    lines.push(`- **Detail:** https://leaderboard.steel.dev/registry/benchmarks/${benchSlug}.md`);
+    lines.push("");
+  }
+
+  lines.push("## See Also");
+  lines.push("");
+  lines.push("- [All benchmarks](https://leaderboard.steel.dev/registry.md)");
+  lines.push("- [All results](https://leaderboard.steel.dev/results.md)");
+  lines.push("- [Full context file](https://leaderboard.steel.dev/llms-full.txt)");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/registry/benchmarks/[benchmark].md.ts
+++ b/src/pages/registry/benchmarks/[benchmark].md.ts
@@ -1,0 +1,91 @@
+// ABOUTME: Astro API endpoint serving markdown versions of individual benchmark detail pages.
+// ABOUTME: Follows the llms.txt spec - accessible at /registry/benchmarks/[benchmark].md.
+
+import type { GetStaticPaths, APIRoute } from "astro";
+import {
+  benchmarks,
+  benchmarkDomainLabels,
+  categorySlugs,
+  getBenchmarkAnchorId,
+  getCategoryPath,
+  categoryRouteLabels,
+} from "../../../lib/benchmarks";
+import type { RoutedCategory } from "../../../lib/benchmarks";
+import { getBenchmarkSummary } from "../../../lib/benchmark-summaries";
+import { indexEntries } from "../../../lib/index-data";
+
+export const getStaticPaths: GetStaticPaths = () => {
+  return benchmarks.map((benchmark) => ({
+    params: { benchmark: getBenchmarkAnchorId(benchmark.name) },
+    props: { benchmark },
+  }));
+};
+
+export const GET: APIRoute = ({ props }) => {
+  const { benchmark } = props as { benchmark: (typeof benchmarks)[number] };
+  const slug = getBenchmarkAnchorId(benchmark.name);
+  const categoryLabel = benchmarkDomainLabels[benchmark.category];
+  const hasRoute = benchmark.category in categorySlugs;
+  const categorySlug = hasRoute ? categorySlugs[benchmark.category as RoutedCategory] : null;
+
+  const summaryParagraphs = getBenchmarkSummary(slug);
+  const results = indexEntries.filter((e) => e.benchmark === benchmark.name);
+
+  const lines: string[] = [];
+
+  lines.push(`# ${benchmark.name}`);
+  lines.push("");
+  lines.push(`> ${benchmark.description}`);
+  lines.push(`> Source: https://leaderboard.steel.dev/registry/benchmarks/${slug} | Maintained by Steel (https://steel.dev)`);
+  lines.push("");
+
+  lines.push("## Overview");
+  lines.push("");
+  lines.push(`- **Category:** ${categoryLabel}`);
+  lines.push(`- **Tasks:** ${benchmark.tasks}`);
+  lines.push(`- **Evaluator:** ${benchmark.evaluator}`);
+  lines.push(`- **Human baseline:** ${benchmark.human}`);
+  lines.push(`- **Self-hosted:** ${benchmark.selfHosted ? "Yes" : "No"}`);
+  if (benchmark.benchmarkOrg) lines.push(`- **Benchmark org:** ${benchmark.benchmarkOrg}`);
+  lines.push(`- **Top agent:** ${benchmark.topAgent} (${benchmark.topOrg}) — ${benchmark.topScore}`);
+  lines.push(`- **Paper:** ${benchmark.paper}`);
+  if (benchmark.github) lines.push(`- **GitHub:** ${benchmark.github}`);
+  lines.push("");
+
+  if (summaryParagraphs && summaryParagraphs.length > 0) {
+    lines.push("## Summary");
+    lines.push("");
+    for (const para of summaryParagraphs) {
+      lines.push(para);
+      lines.push("");
+    }
+  }
+
+  if (results.length > 0) {
+    lines.push("## Results");
+    lines.push("");
+    lines.push("| Rank | Agent | Organization | Score | Open Source | Self-Reported |");
+    lines.push("|------|-------|--------------|-------|-------------|---------------|");
+    results.forEach((entry, i) => {
+      lines.push(
+        `| ${i + 1} | ${entry.agent}${entry.isNew ? " ✦" : ""} | ${entry.organization} | ${entry.score} | ${entry.openSource ? "Yes" : "No"} | ${entry.selfReported ? "Yes" : "No"} |`
+      );
+    });
+    lines.push("");
+    lines.push("✦ = recently added");
+    lines.push("");
+  }
+
+  lines.push("## See Also");
+  lines.push("");
+  if (categorySlug) {
+    lines.push(`- [${categoryLabel} benchmarks](https://leaderboard.steel.dev/registry/${categorySlug}.md)`);
+  }
+  lines.push("- [All benchmarks](https://leaderboard.steel.dev/registry.md)");
+  lines.push("- [All results](https://leaderboard.steel.dev/results.md)");
+  lines.push("- [Full context file](https://leaderboard.steel.dev/llms-full.txt)");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/results.md.ts
+++ b/src/pages/results.md.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Astro API endpoint serving a markdown version of the results index page.
+// ABOUTME: Follows the llms.txt spec - accessible at /results.md.
+
+import type { APIRoute } from "astro";
+import { indexEntries } from "../lib/index-data";
+import { benchmarkDomainLabels } from "../lib/benchmarks";
+
+export const GET: APIRoute = () => {
+  const lines: string[] = [];
+
+  lines.push("# AI Agent Benchmark Results Index");
+  lines.push("");
+  lines.push("> All agent benchmark results across every tracked benchmark.");
+  lines.push("> Source: https://leaderboard.steel.dev/results | Maintained by Steel (https://steel.dev)");
+  lines.push("");
+  lines.push(`${indexEntries.length} results across ${new Set(indexEntries.map((e) => e.benchmark)).size} benchmarks.`);
+  lines.push("");
+
+  const benchmarkNames = [...new Set(indexEntries.map((e) => e.benchmark))];
+
+  for (const benchmarkName of benchmarkNames) {
+    const entries = indexEntries.filter((e) => e.benchmark === benchmarkName);
+    const category = entries[0].benchmarkCategory;
+    const categoryLabel = benchmarkDomainLabels[category];
+
+    lines.push(`## ${benchmarkName}`);
+    lines.push("");
+    lines.push(`**Category:** ${categoryLabel}`);
+    lines.push("");
+    lines.push("| Rank | Agent | Organization | Score | Open Source | Self-Reported |");
+    lines.push("|------|-------|--------------|-------|-------------|---------------|");
+
+    entries.forEach((entry, i) => {
+      lines.push(
+        `| ${i + 1} | ${entry.agent}${entry.isNew ? " ✦" : ""} | ${entry.organization} | ${entry.score} | ${entry.openSource ? "Yes" : "No"} | ${entry.selfReported ? "Yes" : "No"} |`
+      );
+    });
+
+    lines.push("");
+  }
+
+  lines.push("✦ = recently added");
+  lines.push("");
+  lines.push("## See Also");
+  lines.push("");
+  lines.push("- [WebVoyager leaderboard](https://leaderboard.steel.dev/index.md)");
+  lines.push("- [Benchmark registry](https://leaderboard.steel.dev/registry.md)");
+  lines.push("- [Full context file](https://leaderboard.steel.dev/llms-full.txt)");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
- Add @astrojs/sitemap with site URL configured
- Add robots.txt (allow all, sitemap + llms.txt pointers)
- Add public/llms.txt spec-compliant manifest
- Add /llms-full.txt build-time endpoint with all data inlined
- Add .md endpoints for all pages (index, results, registry, per-category, per-benchmark)