### PR TITLE
Add Google Search Console site verification

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -58,6 +58,7 @@ const structuredDataItems = Array.isArray(structuredData)
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content="/og-image.png" />
+    <meta name="google-site-verification" content="u255cG_eERjkv7qF9hArpEz8bdDPLQrfHD6IqCvk4jo" />
     {structuredDataItems.map((item) => (
       <script type="application/ld+json" set:html={item} />
     ))}


### PR DESCRIPTION
## Summary
- Adds Google site verification meta tag to the shared Layout component `<head>` for Search Console ownership verification

## Test plan
- [ ] Verify the meta tag appears in the page source on deployed site
- [ ] Confirm Google Search Console accepts the verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)