### PR TITLE
feat(seo): add custom 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,61 @@
+---
+// ABOUTME: Custom 404 page matching the site's terminal/monospace aesthetic.
+// ABOUTME: Noindexed, with helpful navigation links back to main sections.
+import Layout from "../layouts/Layout.astro";
+import cursorSvg from "../assets/cursor.svg";
+
+const breadcrumbSchema = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    {
+      "@type": "ListItem",
+      position: 1,
+      name: "Home",
+      item: "https://leaderboard.steel.dev/",
+    },
+    {
+      "@type": "ListItem",
+      position: 2,
+      name: "404 — Not Found",
+    },
+  ],
+});
+---
+
+<Layout
+  title="404 — Not Found | Steel Agent Leaderboard"
+  description="This page doesn't exist. Find what you're looking for in the Steel agent leaderboard, benchmark registry, or results index."
+  structuredData={breadcrumbSchema}
+>
+  <div class="w-full max-w-4xl flex flex-col gap-8">
+    <div class="flex flex-col gap-2">
+      <img src={cursorSvg.src} alt="Steel.dev" width="160" height="160" class="mb-4 opacity-80" />
+      <p class="text-accent font-mono text-sm tracking-widest">ERROR_404</p>
+      <h1 class="text-4xl md:text-6xl font-sans tracking-tight text-text">
+        Page not found.
+      </h1>
+      <p class="font-sans text-lg text-text/60 mt-2">
+        This URL doesn't exist. The agent got lost.
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <p class="font-mono text-sm text-text/40 tracking-widest mb-1">NAVIGATE_TO</p>
+      <nav class="flex flex-col gap-2">
+        <a
+          href="/"
+          class="font-mono text-sm text-text hover:text-accent transition-colors duration-300"
+        >[LEADERBOARD] — WebVoyager agent rankings</a>
+        <a
+          href="/registry"
+          class="font-mono text-sm text-text hover:text-accent transition-colors duration-300"
+        >[REGISTRY] — 50+ benchmarks across all categories</a>
+        <a
+          href="/results"
+          class="font-mono text-sm text-text hover:text-accent transition-colors duration-300"
+        >[RESULTS] — All agent scores across every benchmark</a>
+      </nav>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary

- Adds `src/pages/404.astro` with a custom not-found page
- Matches the site's terminal/monospace aesthetic (font, bracket nav links, color palette)
- Includes the cursor SVG at 160×160 for visual identity
- Breadcrumb JSON-LD for structured data
- Helpful navigation links back to `/`, `/registry`, and `/results`
- Astro returns a proper `404` HTTP status automatically — no indexing concerns

## Test plan

- [ ] Visit any non-existent URL (e.g. `/foo`) and confirm the 404 page renders
- [ ] Confirm HTTP status is 404 (check DevTools > Network)
- [ ] Confirm nav links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)