### PR TITLE
add Jina to WebVoyager leaderboard at rank 1 (98.9%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,23 @@ Steel is an open-source browser API purpose-built for AI agents.
 
 | Rank | Agent           | Organization   | WebVoyager Score | Source                                                                                            | Open Source | New | SOTA |
 | ---- | --------------- | -------------- | ---------------- | ------------------------------------------------------------------------------------------------- | ----------- | --- | ---- |
-| 1 | Alumnium   | Alumnium     | 98.5%             | [Source](https://alumnium.ai/blog/webvoyager-benchmark/) | Yes         | Yes | Yes  |
-| 2 | Surfer 2       | H Company     | 97.1%           | [Source](https://hcompany.ai/surfer-2) | No          | Yes | Yes  |
-| 3 | Magnitude      | Magnitude     | 93.9%           | [Source](https://magnitude.run/webvoyager) | Yes         | No |      |
-| 4 | AIME Browser-Use | Aime          | 92.34%          | [Source](https://aime-browser-use.github.io/) | No          | Yes |      |
-| 5 | Surfer-H + Holo1 | H Company     | 92.2%           | [Source](https://arxiv.org/pdf/2506.02865) | No          | Yes |      |
-| 6 | Browserable    | Browserable   | 90.4%           | [Source](https://www.browserable.ai/blog/web-voyager-benchmark) | Yes         | Yes |      |
-| 7 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         | No |      |
-| 8 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          | No |      |
-| 9 | Skyvern 2.0    | Skyvern       | 85.85%          | [Source](https://blog.skyvern.com/skyvern-2-0-state-of-the-art-web-navigation-with-85-8-on-webvoyager-eval/) | Yes         | No |      |
-| 10 | Project Mariner | Google        | 83.5%           | [Source](https://deepmind.google/technologies/project-mariner/) | No          |   No  |      |
-| 11 | Notte          | Notte         | 73.1%           | [Source](https://github.com/nottelabs/open-operator-evals#opensource-operators-evals) | Yes         |  Yes   |      |
-| 12 | Agent-E        | Emergence AI  | 73.1%           | [Source](https://www.emergence.ai/blog/agent-e-sota) | No          | No    |      |
-| 13 | WebSight       | Academic Research | 68%             | [Source](https://arxiv.org/abs/2508.16987) | No          |  No   |      |
-| 14 | Runner H 0.1   | H Company     | 67%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |  No   |      |
-| 15 | WebVoyager     | Academic Research | 59.1%           | [Source](https://arxiv.org/abs/2401.13919) | Yes         |  No   |      |
-| 16 | WILBUR         | Academic Research | 53%             | [Source](https://arxiv.org/abs/2404.05902) | No          |   No  |      |
+| 1 | Jina           | Om Labs       | 98.9%           | [Source](https://webvoyager.omlabs.xyz) | No          | Yes | Yes  |
+| 2 | Alumnium       | Alumnium      | 98.5%           | [Source](https://alumnium.ai/blog/webvoyager-benchmark) | Yes         | Yes |      |
+| 3 | Surfer 2       | H Company     | 97.1%           | [Source](https://hcompany.ai/surfer-2) | No          | Yes |      |
+| 4 | Magnitude      | Magnitude     | 93.9%           | [Source](https://magnitude.run/webvoyager) | Yes         |     |      |
+| 5 | AIME Browser-Use | Aime          | 92.34%          | [Source](https://aime-browser-use.github.io/) | No          | Yes |      |
+| 6 | Surfer-H + Holo1 | H Company     | 92.2%           | [Source](https://arxiv.org/pdf/2506.02865) | No          | Yes |      |
+| 7 | Browserable    | Browserable   | 90.4%           | [Source](https://www.browserable.ai/blog/web-voyager-benchmark) | Yes         | Yes |      |
+| 8 | Browser Use    | Browser Use   | 89.1%           | [Source](https://browser-use.com/posts/sota-technical-report) | Yes         |     |      |
+| 9 | Operator       | OpenAI        | 87%             | [Source](https://openai.com/index/introducing-operator/) | No          |     |      |
+| 10 | Skyvern 2.0    | Skyvern       | 85.85%          | [Source](https://blog.skyvern.com/skyvern-2-0-state-of-the-art-web-navigation-with-85-8-on-webvoyager-eval/) | Yes         |     |      |
+| 11 | Project Mariner | Google        | 83.5%           | [Source](https://deepmind.google/technologies/project-mariner/) | No          |     |      |
+| 12 | Notte          | Notte         | 73.1%           | [Source](https://github.com/nottelabs/open-operator-evals#opensource-operators-evals) | Yes         | Yes |      |
+| 13 | Agent-E        | Emergence AI  | 73.1%           | [Source](https://www.emergence.ai/blog/agent-e-sota) | No          |     |      |
+| 14 | WebSight       | Academic Research | 68%             | [Source](https://arxiv.org/abs/2508.16987) | No          |     |      |
+| 15 | Runner H 0.1   | H Company     | 67%             | [Source](https://www.hcompany.ai/blog/a-research-update) | No          |     |      |
+| 16 | WebVoyager     | Academic Research | 59.1%           | [Source](https://arxiv.org/abs/2401.13919) | Yes         |     |      |
+| 17 | WILBUR         | Academic Research | 53%             | [Source](https://arxiv.org/abs/2404.05902) | No          |     |      |
 
 **Notes:**
 

--- a/src/components/FAQ.astro
+++ b/src/components/FAQ.astro
@@ -2,7 +2,7 @@
 export const faqs = [
   {
     q: "What is the WebVoyager benchmark for AI browser agents?",
-    a: "WebVoyager is the standard benchmark for evaluating browser agents, introduced in the 2024 paper <a href='https://arxiv.org/abs/2401.13919' target='_blank' rel='noopener noreferrer'>WebVoyager: Building an End-to-End Web Agent with Large Multimodal Models</a>. It consists of 643 tasks across 15 websites including Google, Amazon, GitHub, Reddit, and Wikipedia. Tasks cover form filling, navigation, search, and shopping. GPT-4V evaluates each task by analyzing the final page state. Scores represent the percentage of tasks completed successfully. As of February 2026, the highest score is 97.1% held by Surfer 2 from H Company.",
+    a: "WebVoyager is the standard benchmark for evaluating browser agents, introduced in the 2024 paper <a href='https://arxiv.org/abs/2401.13919' target='_blank' rel='noopener noreferrer'>WebVoyager: Building an End-to-End Web Agent with Large Multimodal Models</a>. It consists of 643 tasks across 15 websites including Google, Amazon, GitHub, Reddit, and Wikipedia. Tasks cover form filling, navigation, search, and shopping. GPT-4V evaluates each task by analyzing the final page state. Scores represent the percentage of tasks completed successfully. As of April 2026, the highest score is 98.9% held by Jina from Om Labs.",
   },
   {
     q: "Can WebVoyager scores be compared across different agents?",
@@ -14,7 +14,7 @@ export const faqs = [
   },
   {
     q: "What is the best AI browser agent in 2026?",
-    a: "By WebVoyager score: Surfer 2 at 97.1% (H Company), Magnitude at 93.9%, AIME Browser-Use at 92.34%, Browserable at 90.4%, Browser Use at 89.1%, OpenAI Operator at 87%, Skyvern 2.0 at 85.85%, and Google Project Mariner at 83.5%. Surfer-H (92.2%) is a multi-attempt benchmark (10 attempts), so it is not directly comparable to single-run percentages. Surfer 2 leads accuracy. Browser Use and Skyvern are strong open-source options. Rankings update as new results are submitted.",
+    a: "By WebVoyager score: Jina at 98.9% (Om Labs), Alumnium at 98.5%, Surfer 2 at 97.1% (H Company), Magnitude at 93.9%, AIME Browser-Use at 92.34%, Browserable at 90.4%, Browser Use at 89.1%, OpenAI Operator at 87%, Skyvern 2.0 at 85.85%, and Google Project Mariner at 83.5%. Surfer-H (92.2%) is a multi-attempt benchmark (10 attempts), so it is not directly comparable to single-run percentages. Jina leads accuracy. Browser Use and Skyvern are strong open-source options. Rankings update as new results are submitted.",
   },
   {
     q: "What is the difference between OpenAI Operator, Browser Use, and other AI browser agents?",
@@ -34,11 +34,11 @@ export const faqs = [
   },
   {
     q: "What does SOTA mean?",
-    a: "SOTA stands for State of the Art - the highest-performing result on a benchmark. On this leaderboard, the SOTA badge is awarded to the agent with the highest WebVoyager score and transfers automatically when a new high score is submitted. As of February 2026, the SOTA holder is Surfer 2 by H Company at 97.1%.",
+    a: "SOTA stands for State of the Art - the highest-performing result on a benchmark. On this leaderboard, the SOTA badge is awarded to the agent with the highest WebVoyager score and transfers automatically when a new high score is submitted. As of April 2026, the SOTA holder is Jina by Om Labs at 98.9%.",
   },
   {
     q: "Are OpenAI Operator and Google Project Mariner on this leaderboard?",
-    a: "Yes. OpenAI Operator scores 87% (ranked 6th) and Google Project Mariner scores 83.5% (ranked 8th). Both are consumer products integrated into their ecosystems - Operator via ChatGPT, Mariner via Chrome. They score lower than specialized agents like Surfer 2 (97.1%) because they prioritize broad capability over benchmark optimization.",
+    a: "Yes. OpenAI Operator scores 87% and Google Project Mariner scores 83.5%. Both are consumer products integrated into their ecosystems - Operator via ChatGPT, Mariner via Chrome. They score lower than specialized agents like Jina (98.9%) because they prioritize broad capability over benchmark optimization.",
   },
   {
     q: "How do I build my own AI browser agent?",
@@ -67,6 +67,10 @@ export const faqs = [
   {
     q: "What is Google Project Mariner's WebVoyager benchmark score?",
     a: "Google Project Mariner scores 83.5% on WebVoyager, ranking 8th overall. Built on Gemini and integrated with Chrome, it handles web navigation and form filling. Currently in limited availability.",
+  },
+  {
+    q: "What is Jina's WebVoyager benchmark score?",
+    a: "Jina by Om Labs holds the current SOTA at 98.9% on WebVoyager (603 of 610 tasks) as of April 2026. Jina pairs Claude Opus 4.7 as the browser agent with GPT 5.4 Nano as the Jina MCP planner, judged by gpt-5 vision against up to 15 screenshots per task. Per-task transcripts, screenshots, and judge rationales are published at <a href='https://webvoyager.omlabs.xyz' target='_blank' rel='noopener noreferrer'>webvoyager.omlabs.xyz</a>.",
   },
   {
     q: "What is Surfer 2's WebVoyager benchmark score?",

--- a/src/lib/benchmarks.ts
+++ b/src/lib/benchmarks.ts
@@ -88,7 +88,7 @@ export const benchmarks: BenchmarkEntry[] = [
     category: "WEB NAV",
     name: "WebVoyager",
     description: "643 tasks across 15 live public websites. Evaluated by GPT-4V judge. The most widely adopted web agent benchmark — de facto standard for comparing commercial and research agents.",
-    topAgent: "Surfer 2", topOrg: "H Company", topScore: "97.1%",
+    topAgent: "Jina", topOrg: "Om Labs", topScore: "98.9%",
     tasks: "643", evaluator: "GPT-4V",
     paper: "https://arxiv.org/abs/2401.13919",
     github: "https://github.com/MinorJerry/WebVoyager",

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -12,6 +12,17 @@ export interface LeaderboardEntry {
 
 export const leaderboardEntries: LeaderboardEntry[] = [
   {
+    agent: "Jina",
+    organization: "Om Labs",
+    webVoyager: {
+      score: "98.9%",
+      source: "https://webvoyager.omlabs.xyz",
+    },
+    isNew: true,
+    github: null,
+    homepage: "https://webvoyager.omlabs.xyz",
+  },
+  {
     agent: "Alumnium",
     organization: "Alumnium",
     webVoyager: {


### PR DESCRIPTION
## Summary

Adds Jina (Om Labs) to the WebVoyager leaderboard at **rank 1 with 98.9%** (603/610).

Stack:
- Browser agent: Jina MCP (openai/gpt-5.4-nano)
- Planner: Claude Code (claude-opus-4-7)
- Driver: Playwright
- Judge: gpt-5 with vision (up to 15 screenshots per task)

## Evidence

Full per-task results — transcripts, final answers, screenshots, and the gpt-5 judge rationale for each of the 610 tasks — are at **https://webvoyager.omlabs.xyz**.

## Changes

- `src/lib/leaderboard.ts` — insert Jina at top of \`leaderboardEntries\`
- `src/lib/benchmarks.ts` — update WebVoyager \`topAgent\` / \`topScore\`
- `README.md` — regenerated via \`pnpm update-readme\`
- faqs