### PR TITLE
fix: tooltip overflow + CONTRIBUTING lastUpdated checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,9 @@ Use this section when you already know what kind of change you are making.
 3. Make sure `sourceUrl` directly supports the score.
 4. Write `notesShort` with the setup and caveat that matter most.
 5. Re-rank the file using competition ranking.
-6. Run `npm run update-readme`.
-7. Run `npm run lint` and `npm run build`.
+6. Bump `lastUpdated` on the benchmark's `benchmarkPages` entry in `src/lib/benchmark-hub.ts`.
+7. Run `npm run update-readme`.
+8. Run `npm run lint` and `npm run build`.
 
 ### Add a new leaderboard page
 
@@ -27,7 +28,7 @@ Use this section when you already know what kind of change you are making.
 2. Add `src/data/<benchmarkKey>.json`.
 3. Export it from `src/data/index.ts`.
 4. Add the key to `BenchmarkMap` and `benchmarkMap` in `src/lib/benchmark-hub.ts`.
-5. Add a `benchmarkPages` entry in `src/lib/benchmark-hub.ts`.
+5. Add a `benchmarkPages` entry in `src/lib/benchmark-hub.ts`, including `lastUpdated`.
 6. Add 3 exact public task examples with citations.
 7. Add related benchmarks and canonical links.
 8. Run `npm run update-readme`.
@@ -386,6 +387,7 @@ For submissions:
 - [ ] Ties and ranks are correct.
 - [ ] `reportedAt` reflects the source publication date.
 - [ ] `repoUrl` is present only when useful.
+- [ ] The benchmark's `lastUpdated` was bumped in `src/lib/benchmark-hub.ts`.
 - [ ] `npm run update-readme` was run when data changed.
 - [ ] `npm run lint` was run.
 - [ ] `npm run build` was run.
@@ -398,6 +400,7 @@ For new leaderboards:
 - [ ] The page has 3 exact public task examples with citations.
 - [ ] About, methodology, important notes, links, and related benchmarks are complete.
 - [ ] The page makes scope clear: `agent`, `model`, or `mixed`.
+- [ ] `lastUpdated` is set on the new `benchmarkPages` entry.
 - [ ] The README was regenerated.
 - [ ] `npm run lint` was run.
 - [ ] `npm run build` was run.

--- a/src/components/BenchmarkResultsTable.astro
+++ b/src/components/BenchmarkResultsTable.astro
@@ -151,9 +151,14 @@ function formatReportedDate(reportedAt?: string): string {
                             <path d="M12 8h.01" />
                           </svg>
                         </button>
-                        <span id={`note-${slug}-${row.rank}`} role="tooltip" class="note-bubble">
+                        <div
+                          id={`note-${slug}-${row.rank}`}
+                          role="tooltip"
+                          popover="manual"
+                          class="note-bubble"
+                        >
                           {row.notesShort}
-                        </span>
+                        </div>
                       </span>
                     )}
                   </div>
@@ -200,5 +205,81 @@ function formatReportedDate(reportedAt?: string): string {
       shell.classList.toggle("is-collapsed");
       btn.setAttribute("aria-expanded", String(!shell.classList.contains("is-collapsed")));
     });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>(".note-trigger").forEach((trigger) => {
+    const id = trigger.getAttribute("aria-describedby");
+    if (!id) return;
+    const bubble = document.getElementById(id) as HTMLElement | null;
+    if (!bubble || typeof bubble.showPopover !== "function") return;
+
+    const MARGIN = 8;
+    const HIDE_DELAY_MS = 120;
+    let hideTimer: number | undefined;
+    let isOpen = false;
+
+    const position = (): void => {
+      const triggerRect = trigger.getBoundingClientRect();
+      const bubbleRect = bubble.getBoundingClientRect();
+      const viewportW = document.documentElement.clientWidth;
+      const viewportH = document.documentElement.clientHeight;
+
+      let top = triggerRect.top - bubbleRect.height - MARGIN;
+      let left = triggerRect.left + triggerRect.width / 2 - bubbleRect.width / 2;
+
+      if (top < MARGIN) top = triggerRect.bottom + MARGIN;
+      if (left < MARGIN) left = MARGIN;
+      if (left + bubbleRect.width > viewportW - MARGIN) {
+        left = viewportW - bubbleRect.width - MARGIN;
+      }
+      if (top + bubbleRect.height > viewportH - MARGIN) {
+        top = Math.max(MARGIN, viewportH - bubbleRect.height - MARGIN);
+      }
+
+      bubble.style.top = `${top}px`;
+      bubble.style.left = `${left}px`;
+    };
+
+    const onScrollOrResize = (): void => position();
+
+    const open = (): void => {
+      if (hideTimer !== undefined) {
+        window.clearTimeout(hideTimer);
+        hideTimer = undefined;
+      }
+      if (isOpen) return;
+      isOpen = true;
+      bubble.showPopover();
+      position();
+      window.addEventListener("scroll", onScrollOrResize, true);
+      window.addEventListener("resize", onScrollOrResize);
+    };
+
+    const close = (): void => {
+      if (!isOpen) return;
+      isOpen = false;
+      bubble.hidePopover();
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+
+    const scheduleClose = (): void => {
+      if (hideTimer !== undefined) window.clearTimeout(hideTimer);
+      hideTimer = window.setTimeout(close, HIDE_DELAY_MS);
+    };
+
+    const cancelClose = (): void => {
+      if (hideTimer !== undefined) {
+        window.clearTimeout(hideTimer);
+        hideTimer = undefined;
+      }
+    };
+
+    trigger.addEventListener("mouseenter", open);
+    trigger.addEventListener("mouseleave", scheduleClose);
+    trigger.addEventListener("focus", open);
+    trigger.addEventListener("blur", close);
+    bubble.addEventListener("mouseenter", cancelClose);
+    bubble.addEventListener("mouseleave", scheduleClose);
   });
 </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -422,13 +422,11 @@ details[open] > .lb-row {
 }
 
 .note-bubble {
-  position: absolute;
-  bottom: calc(100% + 0.5rem);
-  left: 50%;
-  z-index: 20;
-  display: none;
-  width: min(18rem, 80vw);
-  transform: translateX(-50%);
+  inset: auto;
+  margin: 0;
+  width: min(18rem, calc(100vw - 1rem));
+  max-width: none;
+  height: auto;
   border: 1px solid var(--color-border);
   border-radius: 0.375rem;
   background: var(--color-surface);
@@ -438,11 +436,7 @@ details[open] > .lb-row {
   font-family: var(--font-sans);
   font-size: 0.75rem;
   line-height: 1.35;
-}
-
-.note-tooltip:hover .note-bubble,
-.note-tooltip:focus-within .note-bubble {
-  display: block;
+  overflow: visible;
 }
 
 .copy-md-control {


### PR DESCRIPTION
## Summary
- Row note tooltips now render in the browser top layer via the HTML Popover API, escaping the .table-shell and .overflow-x-auto clipping that was cutting off the left edge of the bubble for first-column icons. JS positioner auto-flips below when there is no room above and clamps to the viewport on all sides, with a 120 ms hover grace period so the cursor can travel between icon and bubble without flicker.
- CONTRIBUTING.md checklists now call out bumping meta.lastUpdated in src/lib/benchmark-hub.ts. The footer "Last updated" reads from that field since #33 removed the build-time git-shell-out, so contributors need to bump it explicitly.

## Test plan
- [ ] Open /leaderboards/browsecomp/ (long, scrollable table) and hover the (?) icon on row 1 — bubble renders fully visible, not clipped by the table border.
- [ ] Hover an icon near the right edge of the viewport — bubble clamps within the viewport instead of overflowing right.
- [ ] Scroll while a bubble is open — it tracks the trigger.
- [ ] Tab-focus an icon via keyboard — bubble shows; blur — bubble hides.
- [ ] Touch tap on iOS Safari — focus event opens the bubble.
- [ ] pnpm lint && pnpm build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)