### PR TITLE
feat(leaderboard): add Aider leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Coding · Model scope · 15 entries tracked
 
 | Rank | System                                   | Organization | Score                                          |
 | ---: | ---------------------------------------- | ------------ | ---------------------------------------------- |
-|    1 | gpt-5 (high) **(new)**                   | OpenAI       | [88.0%](https://aider.chat/docs/leaderboards/) |
-|    2 | gpt-5 (medium) **(new)**                 | OpenAI       | [86.7%](https://aider.chat/docs/leaderboards/) |
+|    1 | gpt-5 (high)                             | OpenAI       | [88.0%](https://aider.chat/docs/leaderboards/) |
+|    2 | gpt-5 (medium)                           | OpenAI       | [86.7%](https://aider.chat/docs/leaderboards/) |
 |    3 | o3-pro (high)                            | OpenAI       | [84.9%](https://aider.chat/docs/leaderboards/) |
 |    4 | gemini-2.5-pro-preview-06-05 (32k think) | Google       | [83.1%](https://aider.chat/docs/leaderboards/) |
 |    5 | o3 (high)                                | OpenAI       | [81.3%](https://aider.chat/docs/leaderboards/) |

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ Coding · Model scope · 16 entries tracked
 
 ---
 
+### [Aider](https://leaderboard.steel.dev/leaderboards/aider)
+
+Coding · Model scope · 15 entries tracked
+
+| Rank | System                                   | Organization | Score                                          |
+| ---: | ---------------------------------------- | ------------ | ---------------------------------------------- |
+|    1 | gpt-5 (high) **(new)**                   | OpenAI       | [88.0%](https://aider.chat/docs/leaderboards/) |
+|    2 | gpt-5 (medium) **(new)**                 | OpenAI       | [86.7%](https://aider.chat/docs/leaderboards/) |
+|    3 | o3-pro (high)                            | OpenAI       | [84.9%](https://aider.chat/docs/leaderboards/) |
+|    4 | gemini-2.5-pro-preview-06-05 (32k think) | Google       | [83.1%](https://aider.chat/docs/leaderboards/) |
+|    5 | o3 (high)                                | OpenAI       | [81.3%](https://aider.chat/docs/leaderboards/) |
+
+[See all 15 entries →](https://leaderboard.steel.dev/leaderboards/aider)
+
+---
+
 ### [OSWorld](https://leaderboard.steel.dev/leaderboards/osworld)
 
 Computer use · Agent scope · 17 entries tracked

--- a/src/data/aiderPolyglot.json
+++ b/src/data/aiderPolyglot.json
@@ -1,0 +1,159 @@
+{
+  "aiderPolyglot": [
+    {
+      "rank": 1,
+      "systemName": "gpt-5 (high)",
+      "organization": "OpenAI",
+      "scoreDisplay": "88.0%",
+      "scoreValue": 88,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 91.6% well-formed edits, ~$29.08 per run.",
+      "reportedAt": "2025-08-23",
+      "isNew": true
+    },
+    {
+      "rank": 2,
+      "systemName": "gpt-5 (medium)",
+      "organization": "OpenAI",
+      "scoreDisplay": "86.7%",
+      "scoreValue": 86.7,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 88.4% well-formed edits, ~$17.69 per run.",
+      "reportedAt": "2025-08-25",
+      "isNew": true
+    },
+    {
+      "rank": 3,
+      "systemName": "o3-pro (high)",
+      "organization": "OpenAI",
+      "scoreDisplay": "84.9%",
+      "scoreValue": 84.9,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 97.8% well-formed edits, ~$146.32 per run.",
+      "reportedAt": "2025-06-28"
+    },
+    {
+      "rank": 4,
+      "systemName": "gemini-2.5-pro-preview-06-05 (32k think)",
+      "organization": "Google",
+      "scoreDisplay": "83.1%",
+      "scoreValue": 83.1,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff-fenced edit format, 99.6% well-formed edits, ~$49.88 per run.",
+      "reportedAt": "2025-06-06"
+    },
+    {
+      "rank": 5,
+      "systemName": "o3 (high)",
+      "organization": "OpenAI",
+      "scoreDisplay": "81.3%",
+      "scoreValue": 81.3,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 94.7% well-formed edits, ~$21.23 per run.",
+      "reportedAt": "2025-06-25"
+    },
+    {
+      "rank": 5,
+      "systemName": "gpt-5 (low)",
+      "organization": "OpenAI",
+      "scoreDisplay": "81.3%",
+      "scoreValue": 81.3,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 86.7% well-formed edits, ~$10.37 per run.",
+      "reportedAt": "2025-08-25",
+      "isNew": true
+    },
+    {
+      "rank": 7,
+      "systemName": "grok-4 (high)",
+      "organization": "xAI",
+      "scoreDisplay": "79.6%",
+      "scoreValue": 79.6,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 97.3% well-formed edits, ~$59.62 per run.",
+      "reportedAt": "2025-07-11"
+    },
+    {
+      "rank": 8,
+      "systemName": "gemini-2.5-pro-preview-06-05 (default think)",
+      "organization": "Google",
+      "scoreDisplay": "79.1%",
+      "scoreValue": 79.1,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff-fenced edit format, 100% well-formed edits, ~$45.60 per run.",
+      "reportedAt": "2025-06-06"
+    },
+    {
+      "rank": 9,
+      "systemName": "o3 (high) + gpt-4.1",
+      "organization": "OpenAI",
+      "scoreDisplay": "78.2%",
+      "scoreValue": 78.2,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; architect mode (planner + editor), 100% well-formed edits, ~$17.55 per run.",
+      "reportedAt": "2025-06-27"
+    },
+    {
+      "rank": 10,
+      "systemName": "Gemini 2.5 Pro Preview 05-06",
+      "organization": "Google",
+      "scoreDisplay": "76.9%",
+      "scoreValue": 76.9,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff-fenced edit format, 97.3% well-formed edits, ~$37.41 per run.",
+      "reportedAt": "2025-05-07"
+    },
+    {
+      "rank": 10,
+      "systemName": "o3",
+      "organization": "OpenAI",
+      "scoreDisplay": "76.9%",
+      "scoreValue": 76.9,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 93.8% well-formed edits, ~$13.75 per run.",
+      "reportedAt": "2025-06-25"
+    },
+    {
+      "rank": 12,
+      "systemName": "DeepSeek-V3.2-Exp (Reasoner)",
+      "organization": "DeepSeek",
+      "scoreDisplay": "74.2%",
+      "scoreValue": 74.2,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; open-weight model, diff edit format, 97.3% well-formed edits, ~$1.30 per run.",
+      "repoUrl": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp",
+      "reportedAt": "2025-10-03",
+      "isNew": true
+    },
+    {
+      "rank": 13,
+      "systemName": "Gemini 2.5 Pro Preview 03-25",
+      "organization": "Google",
+      "scoreDisplay": "72.9%",
+      "scoreValue": 72.9,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff-fenced edit format, 92.4% well-formed edits.",
+      "reportedAt": "2025-04-12"
+    },
+    {
+      "rank": 14,
+      "systemName": "o4-mini (high)",
+      "organization": "OpenAI",
+      "scoreDisplay": "72.0%",
+      "scoreValue": 72,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 90.7% well-formed edits, ~$19.64 per run.",
+      "reportedAt": "2025-04-16"
+    },
+    {
+      "rank": 14,
+      "systemName": "claude-opus-4-20250514 (32k thinking)",
+      "organization": "Anthropic",
+      "scoreDisplay": "72.0%",
+      "scoreValue": 72,
+      "sourceUrl": "https://aider.chat/docs/leaderboards/",
+      "notesShort": "Official Aider polyglot leaderboard; diff edit format, 97.3% well-formed edits, ~$65.75 per run.",
+      "reportedAt": "2025-05-25"
+    }
+  ]
+}

--- a/src/data/aiderPolyglot.json
+++ b/src/data/aiderPolyglot.json
@@ -8,8 +8,7 @@
       "scoreValue": 88,
       "sourceUrl": "https://aider.chat/docs/leaderboards/",
       "notesShort": "Official Aider polyglot leaderboard; diff edit format, 91.6% well-formed edits, ~$29.08 per run.",
-      "reportedAt": "2025-08-23",
-      "isNew": true
+      "reportedAt": "2025-08-23"
     },
     {
       "rank": 2,
@@ -19,8 +18,7 @@
       "scoreValue": 86.7,
       "sourceUrl": "https://aider.chat/docs/leaderboards/",
       "notesShort": "Official Aider polyglot leaderboard; diff edit format, 88.4% well-formed edits, ~$17.69 per run.",
-      "reportedAt": "2025-08-25",
-      "isNew": true
+      "reportedAt": "2025-08-25"
     },
     {
       "rank": 3,
@@ -60,8 +58,7 @@
       "scoreValue": 81.3,
       "sourceUrl": "https://aider.chat/docs/leaderboards/",
       "notesShort": "Official Aider polyglot leaderboard; diff edit format, 86.7% well-formed edits, ~$10.37 per run.",
-      "reportedAt": "2025-08-25",
-      "isNew": true
+      "reportedAt": "2025-08-25"
     },
     {
       "rank": 7,
@@ -122,8 +119,7 @@
       "sourceUrl": "https://aider.chat/docs/leaderboards/",
       "notesShort": "Official Aider polyglot leaderboard; open-weight model, diff edit format, 97.3% well-formed edits, ~$1.30 per run.",
       "repoUrl": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp",
-      "reportedAt": "2025-10-03",
-      "isNew": true
+      "reportedAt": "2025-10-03"
     },
     {
       "rank": 13,

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,5 @@
 export { default as agentBench } from "./agentBench.json" with { type: "json" };
+export { default as aiderPolyglot } from "./aiderPolyglot.json" with { type: "json" };
 export { default as browsecomp } from "./browsecomp.json" with { type: "json" };
 export { default as clawbench } from "./clawbench.json" with { type: "json" };
 export { default as gaia } from "./gaia.json" with { type: "json" };

--- a/src/lib/benchmark-hub.ts
+++ b/src/lib/benchmark-hub.ts
@@ -1,5 +1,6 @@
 import {
   agentBench,
+  aiderPolyglot,
   browsecomp,
   clawbench,
   gaia,
@@ -13,6 +14,7 @@ import {
 
 type BenchmarkMap = {
   agentBench: Record<string, BenchmarkResultRow[]>;
+  aiderPolyglot: Record<string, BenchmarkResultRow[]>;
   browsecomp: Record<string, BenchmarkResultRow[]>;
   clawbench: Record<string, BenchmarkResultRow[]>;
   gaia: Record<string, BenchmarkResultRow[]>;
@@ -26,6 +28,7 @@ type BenchmarkMap = {
 
 const benchmarkMap: BenchmarkMap = {
   agentBench,
+  aiderPolyglot,
   browsecomp,
   clawbench,
   gaia,
@@ -412,6 +415,79 @@ export const benchmarkPages: BenchmarkPageData[] = [
       lastUpdated: "2026-05-28",
     },
     results: benchmarkResults("sweBenchVerified") ?? [],
+  },
+  {
+    meta: {
+      slug: "aider",
+      name: "Aider",
+      seoName: "Aider",
+      seoTitle: "Aider Leaderboard 2026: LLM Coding Benchmark Scores | Steel.dev",
+      seoDescription:
+        "Compare the Aider LLM leaderboard and Aider benchmark scores: top models on the 225-task Aider Polyglot coding benchmark, with sourced results, pass rates, and methodology.",
+      description:
+        "Aider leaderboard ranking LLMs on the Aider Polyglot benchmark: 225 of the hardest Exercism exercises across C++, Go, Java, JavaScript, Python, and Rust, scored inside Aider's real edit loop.",
+      categoryLabel: "Coding LLM",
+      seoHook: "LLMs editing real code across six languages on 225 of Exercism's hardest exercises",
+      category: "coding",
+      scope: "model",
+      about: [
+        "Aider Polyglot is the coding benchmark behind the Aider pair-programming tool. It tests an LLM on 225 of Exercism's hardest exercises (the ones few models could solve on the earlier single-language benchmark) across C++, Go, Java, JavaScript, Python, and Rust.",
+        "Unlike isolated code-generation tests, Polyglot scores the model inside Aider's real edit loop: the model must emit changes in a structured edit format (diff, diff-fenced, whole, or architect) and gets a second attempt with the failing unit-test output if the first attempt fails.",
+        "Because it measures instruction-following and reliable file editing rather than raw synthesis, the leaderboard is a strong practical signal for choosing a model for an autonomous or pair-programming coding assistant, and it reports cost per run alongside accuracy.",
+      ],
+      methodology: [
+        "Primary metric is percent correct (pass_rate_2): the share of the 225 exercises where all hidden unit tests pass after the model's second attempt.",
+        "A secondary metric, percent using correct edit format, reports how often the model emitted edits Aider could apply without retry; low edit-format compliance drags down effective accuracy.",
+        "Each model runs with Aider's standard prompting and a per-model edit format; some rows fix a thinking-token budget or reasoning effort, which the leaderboard records in the model label.",
+        "Architect-mode rows pair a planner model with a separate editor model, so they are system results rather than single-model numbers; read the model label before comparing.",
+      ],
+      taskExamples: [
+        {
+          quote:
+            "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts on multiple book purchases.",
+          sourceLabel: "Aider polyglot benchmark, book-store exercise",
+          sourceUrl:
+            "https://github.com/Aider-AI/polyglot-benchmark/blob/main/python/exercises/practice/book-store/.docs/instructions.md",
+        },
+        {
+          quote:
+            "Given students' names along with the grade that they are in, create a roster for the school.",
+          sourceLabel: "Aider polyglot benchmark, grade-school exercise",
+          sourceUrl:
+            "https://github.com/Aider-AI/polyglot-benchmark/blob/main/python/exercises/practice/grade-school/.docs/instructions.md",
+        },
+        {
+          quote: "Pick the best hand(s) from a list of poker hands.",
+          sourceLabel: "Aider polyglot benchmark, poker exercise",
+          sourceUrl:
+            "https://github.com/Aider-AI/polyglot-benchmark/blob/main/python/exercises/practice/poker/.docs/instructions.md",
+        },
+      ],
+      importantNotes: [
+        "Numbers are the official Aider polyglot leaderboard; frontier models released after Aider's last run may be missing until it re-runs them.",
+        "Aider also has an older single-language code-editing leaderboard; this page tracks only the modern Polyglot benchmark, so do not mix scores from the two.",
+        "Architect-mode and planner+editor rows are system results, not single-model numbers; rows with a thinking-token or reasoning-effort label are configuration-specific.",
+      ],
+      links: [
+        { label: "Aider polyglot leaderboard", url: "https://aider.chat/docs/leaderboards/" },
+        {
+          label: "Polyglot benchmark announcement & methodology",
+          url: "https://aider.chat/2024/12/21/polyglot.html",
+        },
+        {
+          label: "Polyglot exercises repository",
+          url: "https://github.com/Aider-AI/polyglot-benchmark",
+        },
+        { label: "Aider repository", url: "https://github.com/Aider-AI/aider" },
+        {
+          label: "Leaderboard data file (YAML)",
+          url: "https://github.com/Aider-AI/aider/blob/main/aider/website/_data/polyglot_leaderboard.yml",
+        },
+      ],
+      relatedBenchmarks: ["swe-bench-verified", "tau-bench", "agentbench"],
+      lastUpdated: "2026-06-08",
+    },
+    results: benchmarkResults("aiderPolyglot") ?? [],
   },
   {
     meta: {

--- a/src/lib/benchmark-hub.ts
+++ b/src/lib/benchmark-hub.ts
@@ -421,7 +421,6 @@ export const benchmarkPages: BenchmarkPageData[] = [
       slug: "aider",
       name: "Aider",
       seoName: "Aider",
-      seoTitle: "Aider Leaderboard 2026: LLM Coding Benchmark Scores | Steel.dev",
       seoDescription:
         "Compare the Aider LLM leaderboard and Aider benchmark scores: top models on the 225-task Aider Polyglot coding benchmark, with sourced results, pass rates, and methodology.",
       description:


### PR DESCRIPTION
Closes #28.

Adds a new `/leaderboards/aider/` page for the Aider coding leaderboard, tracking the Aider Polyglot benchmark (225 of Exercism's hardest exercises across C++, Go, Java, JavaScript, Python, and Rust, scored inside Aider's real edit loop).

## Scope decision
Per the issue's "decide whether to track the main benchmark, Polyglot, or both," I tracked the modern Polyglot benchmark (the current canonical Aider leaderboard) rather than the legacy single-language one, whose data is scattered and stale. The page notes the legacy benchmark exists so the variant is unambiguous. The slug is `/leaderboards/aider/` to serve the primary "aider leaderboard" search demand, and the page copy makes the Polyglot scope explicit.

## Data
The top 15 rows live in `src/data/aiderPolyglot.json`. Percent-correct (pass_rate_2), edit format, well-formed percentage, cost, and per-run date are taken verbatim from the official leaderboard's backing data file (`Aider-AI/aider .../_data/polyglot_leaderboard.yml`) and cross-checked against https://aider.chat/docs/leaderboards/ . Competition ranking is used for ties, and every row links to the official leaderboard as its source.

## Screenshot
![Aider leaderboard page rendered at /leaderboards/aider/](https://raw.githubusercontent.com/PeterWadie/leaderboard/pr-assets/aider-leaderboard.jpg)

## New leaderboard checklist
- [x] The benchmark meets the acceptance standard (official public leaderboard with a stable URL and a machine-readable backing data file).
- [x] The data file is added and exported.
- [x] `BenchmarkMap`, `benchmarkMap`, and `benchmarkPages` are updated.
- [x] The page has 3 exact public task examples with citations.
- [x] About, methodology, important notes, links, and related benchmarks are complete.
- [x] The page makes scope clear (`model`).
- [x] `lastUpdated` is set on the new `benchmarkPages` entry.
- [x] The README was regenerated.
- [x] `npm run lint` was run (only pre-existing unrelated errors in `src/scripts/discover-results.ts` remain).
- [x] `npm run build` was run.
