### PR TITLE
feat(leaderboard): add HealthAdminBench leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ Browser agents · Agent scope · 7 entries tracked
 
 ---
 
+### [HealthAdminBench](https://leaderboard.steel.dev/leaderboards/healthadminbench)
+
+Browser agents · Agent scope · 11 entries tracked
+
+| Rank | System                                        | Organization | Score                                                                  |
+| ---: | --------------------------------------------- | ------------ | ---------------------------------------------------------------------- |
+|    1 | Claude Mythos 5 (browser-use) **(new)**       | Anthropic    | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+|    1 | Claude Opus 4.8 (browser-use) **(new)**       | Anthropic    | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+|    3 | Claude Mythos Preview (browser-use) **(new)** | Anthropic    | [47.4%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+|    4 | Claude Sonnet 4.6 (browser-use) **(new)**     | Anthropic    | [45.2%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+|    5 | Claude Opus 4.6 CUA **(new)**                 | Anthropic    | [36.3%](https://arxiv.org/abs/2604.09937)                              |
+
+[See all 11 entries →](https://leaderboard.steel.dev/leaderboards/healthadminbench)
+
+---
+
 ### [Online-Mind2Web](https://leaderboard.steel.dev/leaderboards/online-mind2web)
 
 Browser agents · Agent scope · 22 entries tracked

--- a/src/data/healthAdminBench.json
+++ b/src/data/healthAdminBench.json
@@ -1,0 +1,125 @@
+{
+  "healthAdminBench": [
+    {
+      "rank": 1,
+      "systemName": "Claude Mythos 5 (browser-use)",
+      "organization": "Anthropic",
+      "scoreDisplay": "51.9%",
+      "scoreValue": 51.9,
+      "sourceUrl": "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+      "notesShort": "Anthropic-run internal port with a browser-use scaffold, per-portal skill files, and a single trial; Anthropic flags it as not directly comparable to the published leaderboard.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 1,
+      "systemName": "Claude Opus 4.8 (browser-use)",
+      "organization": "Anthropic",
+      "scoreDisplay": "51.9%",
+      "scoreValue": 51.9,
+      "sourceUrl": "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+      "notesShort": "Same Anthropic internal-port setup as the Mythos 5 row, and also the grader model for the run's LLM-judged subtasks; ties its successor at 51.9%.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 3,
+      "systemName": "Claude Mythos Preview (browser-use)",
+      "organization": "Anthropic",
+      "scoreDisplay": "47.4%",
+      "scoreValue": 47.4,
+      "sourceUrl": "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+      "notesShort": "Anthropic internal-port run with browser-use scaffold and per-portal skill files, single trial; not directly comparable to the paper harness rows.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 4,
+      "systemName": "Claude Sonnet 4.6 (browser-use)",
+      "organization": "Anthropic",
+      "scoreDisplay": "45.2%",
+      "scoreValue": 45.2,
+      "sourceUrl": "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+      "notesShort": "Anthropic internal-port run with browser-use scaffold and per-portal skill files, single trial; not directly comparable to the paper harness rows.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 5,
+      "systemName": "Claude Opus 4.6 CUA",
+      "organization": "Anthropic",
+      "scoreDisplay": "36.3%",
+      "scoreValue": 36.3,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Native Anthropic computer-use system; best paper result under the headline screenshot-only, task-description-plus-portal-guidance configuration.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    },
+    {
+      "rank": 6,
+      "systemName": "GPT-5.4 CUA",
+      "organization": "OpenAI",
+      "scoreDisplay": "26.7%",
+      "scoreValue": 26.7,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Native OpenAI computer-use loop; highest subtask success in the paper but weaker end-to-end completion than Claude Opus 4.6 CUA.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    },
+    {
+      "rank": 7,
+      "systemName": "Kimi K2.5",
+      "organization": "Moonshot AI",
+      "scoreDisplay": "15.6%",
+      "scoreValue": 15.6,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Paper's standardized harness with screenshot-only observations and portal guidance prompting; strongest harness-based model.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    },
+    {
+      "rank": 8,
+      "systemName": "Claude Opus 4.6",
+      "organization": "Anthropic",
+      "scoreDisplay": "14.8%",
+      "scoreValue": 14.8,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Standardized harness, screenshot-only; the paper notes it reaches 51.9% under accessibility-tree observations, showing how much observation mode matters.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    },
+    {
+      "rank": 9,
+      "systemName": "Qwen 3.5",
+      "organization": "Alibaba",
+      "scoreDisplay": "13.3%",
+      "scoreValue": 13.3,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Paper's standardized harness with screenshot-only observations and portal guidance prompting.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    },
+    {
+      "rank": 10,
+      "systemName": "Gemini 3.1 Pro",
+      "organization": "Google",
+      "scoreDisplay": "11.9%",
+      "scoreValue": 11.9,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Paper's standardized harness with screenshot-only observations and portal guidance prompting.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    },
+    {
+      "rank": 11,
+      "systemName": "GPT-5.4",
+      "organization": "OpenAI",
+      "scoreDisplay": "5.9%",
+      "scoreValue": 5.9,
+      "sourceUrl": "https://arxiv.org/abs/2604.09937",
+      "notesShort": "Standardized harness, screenshot-only; far below its native CUA result, underlining the impact of system-level orchestration.",
+      "reportedAt": "2026-04",
+      "isNew": true
+    }
+  ]
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -3,6 +3,7 @@ export { default as aiderPolyglot } from "./aiderPolyglot.json" with { type: "js
 export { default as browsecomp } from "./browsecomp.json" with { type: "json" };
 export { default as clawbench } from "./clawbench.json" with { type: "json" };
 export { default as gaia } from "./gaia.json" with { type: "json" };
+export { default as healthAdminBench } from "./healthAdminBench.json" with { type: "json" };
 export { default as mind2web } from "./mind2web.json" with { type: "json" };
 export { default as osworld } from "./osworld.json" with { type: "json" };
 export { default as sweBenchVerified } from "./sweBenchVerified.json" with { type: "json" };

--- a/src/lib/benchmark-hub.ts
+++ b/src/lib/benchmark-hub.ts
@@ -4,6 +4,7 @@ import {
   browsecomp,
   clawbench,
   gaia,
+  healthAdminBench,
   mind2web,
   osworld,
   sweBenchVerified,
@@ -18,6 +19,7 @@ type BenchmarkMap = {
   browsecomp: Record<string, BenchmarkResultRow[]>;
   clawbench: Record<string, BenchmarkResultRow[]>;
   gaia: Record<string, BenchmarkResultRow[]>;
+  healthAdminBench: Record<string, BenchmarkResultRow[]>;
   mind2web: Record<string, BenchmarkResultRow[]>;
   osworld: Record<string, BenchmarkResultRow[]>;
   sweBenchVerified: Record<string, BenchmarkResultRow[]>;
@@ -32,6 +34,7 @@ const benchmarkMap: BenchmarkMap = {
   browsecomp,
   clawbench,
   gaia,
+  healthAdminBench,
   mind2web,
   osworld,
   sweBenchVerified,
@@ -661,6 +664,76 @@ export const benchmarkPages: BenchmarkPageData[] = [
       lastUpdated: "2026-04-16",
     },
     results: benchmarkResults("clawbench") ?? [],
+  },
+  {
+    meta: {
+      slug: "healthadminbench",
+      name: "HealthAdminBench",
+      description:
+        "HealthAdminBench leaderboard for computer-use agents completing 135 healthcare administration tasks — prior authorization, denials and appeals, and DME orders — across four simulated GUI portals.",
+      categoryLabel: "Healthcare Admin Agent",
+      seoHook:
+        "computer-use agents on 135 healthcare administration tasks across four simulated portals",
+      category: "browser_agents",
+      scope: "agent",
+      about: [
+        "HealthAdminBench evaluates computer-use agents on healthcare revenue-cycle work: 135 expert-designed tasks covering prior authorization, appeals and denials management, and durable medical equipment (DME) order processing, executed in four simulated GUI environments (an EHR, two payer portals, and a fax system). It was built by Stanford's Shah Lab with Stanford Healthcare and Kinetic Systems.",
+        "Each task decomposes into fine-grained verifiable subtasks — 1,698 evaluation points in total — scored by deterministic portal-state checks plus LLM-judged rubric items for free-text documentation and clinical reasoning. Full-task success requires passing every subtask, making it a strict end-to-end reliability measure.",
+        "The benchmark's headline finding is the gap between subtask and full-task performance: agents routinely complete 70–95% of subtasks while finishing far fewer whole workflows, which mirrors the reliability bar real back-office automation has to clear.",
+      ],
+      methodology: [
+        "Headline metric is full-task success rate (pass@1 over 135 tasks): a task counts only if all of its subtasks pass. Subtask success rate is reported alongside it and is much higher for every agent.",
+        "The paper's default configuration is screenshot-only observations with task-description-plus-portal-guidance prompting; configuration moves scores dramatically (Claude Opus 4.6 jumps from 14.8% to 51.9% with accessibility-tree observations, and task-specific prompts push harness agents above 90%).",
+        "Rows mix two harness families: the paper's standardized harness, native computer-use systems (Anthropic and OpenAI CUA loops), and Anthropic's internal browser-use port from its system card; compare within a family before comparing across.",
+        "Anthropic's system card rows used an internal port of the benchmark with a browser-use agent, adaptive thinking, a 500k-token per-task budget, per-portal skill files, and a single trial per model, with Claude Opus 4.8 grading the LLM-judged subtasks; Anthropic states these results are not directly comparable to the published leaderboard.",
+      ],
+      taskExamples: [
+        {
+          quote:
+            "Open referral REF-2025-002 for Smith, Emily (67F with Santa Clara Family Health Plan - Medicare Advantage). Determine whether the payer requires prior authorization for this eye follow-up visit. Document your determination, then clear the referral from the worklist.",
+          sourceLabel: "HealthAdminBench task explorer",
+          sourceUrl:
+            "https://som-shahlab.github.io/health-admin-bench-website/data/master_json.json",
+        },
+        {
+          quote:
+            "Open denial DEN-001 for Martinez, Carlos. Review all available information about this denial and determine the appropriate triage disposition. Document your reasoning in a triage note.",
+          sourceLabel: "HealthAdminBench task explorer",
+          sourceUrl:
+            "https://som-shahlab.github.io/health-admin-bench-website/data/master_json.json",
+        },
+        {
+          quote:
+            "Download all 3 required documents, fax to DME supplier, and document in the Notes tab.",
+          sourceLabel: "HealthAdminBench task explorer",
+          sourceUrl:
+            "https://som-shahlab.github.io/health-admin-bench-website/data/master_json.json",
+        },
+      ],
+      importantNotes: [
+        "New benchmark with no independent submissions yet: current rows are the paper authors' baselines plus Anthropic's self-reported system card run.",
+        "Anthropic system card rows come from an internal port with a browser-use scaffold, per-portal skill files, and a single trial, and were self-graded by Claude Opus 4.8; Anthropic itself flags them as not directly comparable to the published leaderboard.",
+        "Setup differences (observation mode, prompting, orchestration) move scores more than model choice does on this page, so read the Notes column before treating rank gaps as capability gaps.",
+      ],
+      links: [
+        { label: "HealthAdminBench paper", url: "https://arxiv.org/abs/2604.09937" },
+        {
+          label: "Project site and leaderboard",
+          url: "https://som-shahlab.github.io/health-admin-bench-website/",
+        },
+        {
+          label: "HealthAdminBench repository",
+          url: "https://github.com/som-shahlab/health-admin-bench",
+        },
+        {
+          label: "Claude Fable 5 & Mythos 5 system card",
+          url: "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+        },
+      ],
+      relatedBenchmarks: ["webarena", "osworld", "clawbench"],
+      lastUpdated: "2026-06-12",
+    },
+    results: benchmarkResults("healthAdminBench") ?? [],
   },
   {
     meta: {


### PR DESCRIPTION
## Summary

Adds **HealthAdminBench** (Stanford Shah Lab / Stanford Healthcare / Kinetic Systems): 135 healthcare revenue-cycle tasks (prior auth, denials & appeals, DME orders) across four simulated GUI portals, scored as full-task pass@1 over 1,698 verifiable subtasks.

Rows cover the paper's headline configuration (screenshot-only, task description + portal guidance) for seven systems, plus four Anthropic-reported browser-use runs from the Claude Fable 5 & Mythos 5 system card (flagged as an internal port, single trial, not directly comparable per Anthropic's own caveat).

## Changes
- `src/data/healthAdminBench.json` — leaderboard data
- `src/data/index.ts` — register dataset
- `src/lib/benchmark-hub.ts` — hub metadata
- `README.md` — generated table entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)