### PR TITLE
webvoyager: add browser-control (Fable 5, Opus 4.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ The tables below show the current top entries on each tracked benchmark. Each se
 
 ### [WebVoyager](https://leaderboard.steel.dev/leaderboards/webvoyager)
 
-Browser agents · Agent scope · 19 entries tracked
+Browser agents · Agent scope · 21 entries tracked
 
-| Rank | System             | Organization | Score                                                          |
-| ---: | ------------------ | ------------ | -------------------------------------------------------------- |
-|    1 | Alumnium **(new)** | Alumnium     | [98.5%](https://alumnium.ai/blog/webvoyager-benchmark/)        |
-|    2 | Surfer 2           | H Company    | [97.1%](https://hcompany.ai/surfer-2)                          |
-|    3 | Magnitude          | Magnitude    | [93.9%](https://magnitude.run/webvoyager)                      |
-|    4 | Surfer-H + Holo1   | H Company    | [92.2%](https://arxiv.org/pdf/2506.02865)                      |
-|    5 | Browserable        | Browserable  | [90.4%](https://www.browserable.ai/blog/web-voyager-benchmark) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | browser-control (Fable 5) **(new)** | browser-control | [99.19%](https://github.com/omxyz/webvoyager) |
+| 2 | Alumnium **(new)** | Alumnium | [98.5%](https://alumnium.ai/blog/webvoyager-benchmark/) |
+| 3 | Surfer 2 | H Company | [97.1%](https://hcompany.ai/surfer-2) |
+| 4 | Magnitude | Magnitude | [93.9%](https://magnitude.run/webvoyager) |
+| 5 | Surfer-H + Holo1 | H Company | [92.2%](https://arxiv.org/pdf/2506.02865) |
 
-[See all 19 entries →](https://leaderboard.steel.dev/leaderboards/webvoyager)
+[See all 21 entries →](https://leaderboard.steel.dev/leaderboards/webvoyager)
 
 ---
 
@@ -34,13 +34,13 @@ Browser agents · Agent scope · 19 entries tracked
 
 Research/search · Mixed scope · 82 entries tracked
 
-| Rank | System                | Organization | Score                                                                                                                                                                               |
-| ---: | --------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|    1 | GPT-5.5 Pro           | OpenAI       | [90.1%](https://openai.com/index/introducing-gpt-5-5/)                                                                                                                              |
-|    2 | GPT-5.4 Pro           | OpenAI       | [89.3%](https://openai.com/index/introducing-gpt-5-5/)                                                                                                                              |
-|    3 | MiroThinker-H1        | MiroMind     | [88.2%](https://www.prnewswire.com/news-releases/miromind-team-unveils-mirothinker-1-7--mirothinker-h1-a-new-era-of-verification-centric-heavy-duty-research-agents-302714500.html) |
-|    4 | Claude Mythos Preview | Anthropic    | [86.9%](https://www.anthropic.com/glasswing)                                                                                                                                        |
-|    5 | Kimi K2.6             | Moonshot AI  | [86.3%](https://www.kimi.com/blog/kimi-k2-6)                                                                                                                                        |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | GPT-5.5 Pro | OpenAI | [90.1%](https://openai.com/index/introducing-gpt-5-5/) |
+| 2 | GPT-5.4 Pro | OpenAI | [89.3%](https://openai.com/index/introducing-gpt-5-5/) |
+| 3 | MiroThinker-H1 | MiroMind | [88.2%](https://www.prnewswire.com/news-releases/miromind-team-unveils-mirothinker-1-7--mirothinker-h1-a-new-era-of-verification-centric-heavy-duty-research-agents-302714500.html) |
+| 4 | Claude Mythos Preview | Anthropic | [86.9%](https://www.anthropic.com/glasswing) |
+| 5 | Kimi K2.6 | Moonshot AI | [86.3%](https://www.kimi.com/blog/kimi-k2-6) |
 
 [See all 82 entries →](https://leaderboard.steel.dev/leaderboards/browsecomp)
 
@@ -50,13 +50,13 @@ Research/search · Mixed scope · 82 entries tracked
 
 Browser agents · Agent scope · 49 entries tracked
 
-| Rank | System                    | Organization | Score                                                                                        |
-| ---: | ------------------------- | ------------ | -------------------------------------------------------------------------------------------- |
-|    1 | WebTactix (DeepSeek v3.2) | WebTactix    | [74.3%](https://paper-submission-anoymous.github.io/webtactix_introduction/)                 |
-|    2 | OpAgent                   | CodeFuse AI  | [71.6%](https://github.com/codefuse-ai/OpAgent)                                              |
-|    3 | ColorBrowserAgent         | MadeAgents   | [71.2%](https://arxiv.org/abs/2601.07262)                                                    |
-|    4 | Claude Code + GBOX MCP    | GBOX AI      | [68.0%](https://github.com/babelcloud/webarena/blob/main/gbox/report.md)                     |
-|    5 | DeepSky Agent             | DeepSky      | [66.9%](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | WebTactix (DeepSeek v3.2) | WebTactix | [74.3%](https://paper-submission-anoymous.github.io/webtactix_introduction/) |
+| 2 | OpAgent | CodeFuse AI | [71.6%](https://github.com/codefuse-ai/OpAgent) |
+| 3 | ColorBrowserAgent | MadeAgents | [71.2%](https://arxiv.org/abs/2601.07262) |
+| 4 | Claude Code + GBOX MCP | GBOX AI | [68.0%](https://github.com/babelcloud/webarena/blob/main/gbox/report.md) |
+| 5 | DeepSky Agent | DeepSky | [66.9%](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ) |
 
 [See all 49 entries →](https://leaderboard.steel.dev/leaderboards/webarena)
 
@@ -66,13 +66,13 @@ Browser agents · Agent scope · 49 entries tracked
 
 Coding · Model scope · 16 entries tracked
 
-| Rank | System                    | Organization | Score                                                                                            |
-| ---: | ------------------------- | ------------ | ------------------------------------------------------------------------------------------------ |
-|    1 | Claude Mythos             | Anthropic    | [93.9%](https://www.mindstudio.ai/blog/claude-mythos-benchmark-results-swe-bench-agentic-coding) |
-|    2 | Claude Opus 4.8 **(new)** | Anthropic    | [88.6%](https://www.anthropic.com/news/claude-opus-4-8)                                          |
-|    3 | Claude Opus 4.7           | Anthropic    | [87.6%](https://www.anthropic.com/news/claude-opus-4-7)                                          |
-|    4 | Claude Opus 4.5           | Anthropic    | [80.9%](https://www.anthropic.com/news/claude-opus-4-5)                                          |
-|    5 | Claude Opus 4.6           | Anthropic    | [80.8%](https://www.anthropic.com/news/claude-opus-4-6)                                          |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Mythos | Anthropic | [93.9%](https://www.mindstudio.ai/blog/claude-mythos-benchmark-results-swe-bench-agentic-coding) |
+| 2 | Claude Opus 4.8 **(new)** | Anthropic | [88.6%](https://www.anthropic.com/news/claude-opus-4-8) |
+| 3 | Claude Opus 4.7 | Anthropic | [87.6%](https://www.anthropic.com/news/claude-opus-4-7) |
+| 4 | Claude Opus 4.5 | Anthropic | [80.9%](https://www.anthropic.com/news/claude-opus-4-5) |
+| 5 | Claude Opus 4.6 | Anthropic | [80.8%](https://www.anthropic.com/news/claude-opus-4-6) |
 
 [See all 16 entries →](https://leaderboard.steel.dev/leaderboards/swe-bench-verified)
 
@@ -82,13 +82,13 @@ Coding · Model scope · 16 entries tracked
 
 Coding · Model scope · 15 entries tracked
 
-| Rank | System                                   | Organization | Score                                          |
-| ---: | ---------------------------------------- | ------------ | ---------------------------------------------- |
-|    1 | gpt-5 (high)                             | OpenAI       | [88.0%](https://aider.chat/docs/leaderboards/) |
-|    2 | gpt-5 (medium)                           | OpenAI       | [86.7%](https://aider.chat/docs/leaderboards/) |
-|    3 | o3-pro (high)                            | OpenAI       | [84.9%](https://aider.chat/docs/leaderboards/) |
-|    4 | gemini-2.5-pro-preview-06-05 (32k think) | Google       | [83.1%](https://aider.chat/docs/leaderboards/) |
-|    5 | o3 (high)                                | OpenAI       | [81.3%](https://aider.chat/docs/leaderboards/) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | gpt-5 (high) | OpenAI | [88.0%](https://aider.chat/docs/leaderboards/) |
+| 2 | gpt-5 (medium) | OpenAI | [86.7%](https://aider.chat/docs/leaderboards/) |
+| 3 | o3-pro (high) | OpenAI | [84.9%](https://aider.chat/docs/leaderboards/) |
+| 4 | gemini-2.5-pro-preview-06-05 (32k think) | Google | [83.1%](https://aider.chat/docs/leaderboards/) |
+| 5 | o3 (high) | OpenAI | [81.3%](https://aider.chat/docs/leaderboards/) |
 
 [See all 15 entries →](https://leaderboard.steel.dev/leaderboards/aider)
 
@@ -98,13 +98,13 @@ Coding · Model scope · 15 entries tracked
 
 Computer use · Agent scope · 17 entries tracked
 
-| Rank | System                    | Organization   | Score                                                   |
-| ---: | ------------------------- | -------------- | ------------------------------------------------------- |
-|    1 | Claude Opus 4.8 **(new)** | Anthropic      | [83.4%](https://www.anthropic.com/news/claude-opus-4-8) |
-|    2 | Mythos Preview **(new)**  | Anthropic      | [79.6%](https://www.anthropic.com/glasswing)            |
-|    3 | OSAgent                   | TheAGI Company | [76.26%](https://www.theagi.company/blog/osworld)       |
-|    4 | GPT-5.4 **(new)**         | OpenAI         | [75.0%](https://openai.com/index/introducing-gpt-5-4/)  |
-|    5 | Claude Opus 4.6           | Anthropic      | [72.7%](https://www.anthropic.com/glasswing)            |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Opus 4.8 **(new)** | Anthropic | [83.4%](https://www.anthropic.com/news/claude-opus-4-8) |
+| 2 | Mythos Preview **(new)** | Anthropic | [79.6%](https://www.anthropic.com/glasswing) |
+| 3 | OSAgent | TheAGI Company | [76.26%](https://www.theagi.company/blog/osworld) |
+| 4 | GPT-5.4 **(new)** | OpenAI | [75.0%](https://openai.com/index/introducing-gpt-5-4/) |
+| 5 | Claude Opus 4.6 | Anthropic | [72.7%](https://www.anthropic.com/glasswing) |
 
 [See all 17 entries →](https://leaderboard.steel.dev/leaderboards/osworld)
 
@@ -114,13 +114,13 @@ Computer use · Agent scope · 17 entries tracked
 
 Model evals / reasoning · Agent scope · 21 entries tracked
 
-| Rank | System                             | Organization                 | Score                                                                              |
-| ---: | ---------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------- |
-|    1 | OPS-Agentic-Search **(new)**       | Alibaba Cloud                | [92.36%](https://gaia-benchmark-leaderboard.hf.space/ant_test)                     |
-|    1 | openJiuwen-deepagent **(new)**     | Suzhou AI Lab / Shuqian Tech | [92.36%](https://gitcode.com/openJiuwen/agent-store/tree/main/community/deepagent) |
-|    3 | openJiuwen-deepagent (GPT5/Gemini) | openJiuwen                   | [91.69%](https://gaia-benchmark-leaderboard.hf.space/ant_test)                     |
-|    4 | Lemon Agent                        | Lenovo CTO Org               | [91.36%](https://github.com/Open-Lemon/LemonAgent)                                 |
-|    5 | JoinAI V2.2                        | JoinAI-CMCC                  | [90.7%](https://gaia-benchmark-leaderboard.hf.space/ant_test)                      |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | OPS-Agentic-Search **(new)** | Alibaba Cloud | [92.36%](https://gaia-benchmark-leaderboard.hf.space/ant_test) |
+| 1 | openJiuwen-deepagent **(new)** | Suzhou AI Lab / Shuqian Tech | [92.36%](https://gitcode.com/openJiuwen/agent-store/tree/main/community/deepagent) |
+| 3 | openJiuwen-deepagent (GPT5/Gemini) | openJiuwen | [91.69%](https://gaia-benchmark-leaderboard.hf.space/ant_test) |
+| 4 | Lemon Agent | Lenovo CTO Org | [91.36%](https://github.com/Open-Lemon/LemonAgent) |
+| 5 | JoinAI V2.2 | JoinAI-CMCC | [90.7%](https://gaia-benchmark-leaderboard.hf.space/ant_test) |
 
 [See all 21 entries →](https://leaderboard.steel.dev/leaderboards/gaia)
 
@@ -130,13 +130,13 @@ Model evals / reasoning · Agent scope · 21 entries tracked
 
 Browser agents · Agent scope · 7 entries tracked
 
-| Rank | System            | Organization | Score                                     |
-| ---: | ----------------- | ------------ | ----------------------------------------- |
-|    1 | Claude Sonnet 4.6 | Anthropic    | [33.3%](https://arxiv.org/abs/2604.08523) |
-|    2 | GLM-5 **(new)**   | Z.ai         | [24.2%](https://arxiv.org/abs/2604.08523) |
-|    3 | Gemini 3 Flash    | Google       | [19.0%](https://arxiv.org/abs/2604.08523) |
-|    4 | Claude Haiku 4.5  | Anthropic    | [18.3%](https://arxiv.org/abs/2604.08523) |
-|    5 | GPT-5.4           | OpenAI       | [6.5%](https://arxiv.org/abs/2604.08523)  |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Sonnet 4.6 | Anthropic | [33.3%](https://arxiv.org/abs/2604.08523) |
+| 2 | GLM-5 **(new)** | Z.ai | [24.2%](https://arxiv.org/abs/2604.08523) |
+| 3 | Gemini 3 Flash | Google | [19.0%](https://arxiv.org/abs/2604.08523) |
+| 4 | Claude Haiku 4.5 | Anthropic | [18.3%](https://arxiv.org/abs/2604.08523) |
+| 5 | GPT-5.4 | OpenAI | [6.5%](https://arxiv.org/abs/2604.08523) |
 
 [See all 7 entries →](https://leaderboard.steel.dev/leaderboards/clawbench)
 
@@ -146,13 +146,13 @@ Browser agents · Agent scope · 7 entries tracked
 
 Browser agents · Agent scope · 11 entries tracked
 
-| Rank | System                                        | Organization | Score                                                                  |
-| ---: | --------------------------------------------- | ------------ | ---------------------------------------------------------------------- |
-|    1 | Claude Mythos 5 (browser-use) **(new)**       | Anthropic    | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    1 | Claude Opus 4.8 (browser-use) **(new)**       | Anthropic    | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    3 | Claude Mythos Preview (browser-use) **(new)** | Anthropic    | [47.4%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    4 | Claude Sonnet 4.6 (browser-use) **(new)**     | Anthropic    | [45.2%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    5 | Claude Opus 4.6 CUA **(new)**                 | Anthropic    | [36.3%](https://arxiv.org/abs/2604.09937)                              |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Mythos 5 (browser-use) **(new)** | Anthropic | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 1 | Claude Opus 4.8 (browser-use) **(new)** | Anthropic | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 3 | Claude Mythos Preview (browser-use) **(new)** | Anthropic | [47.4%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 4 | Claude Sonnet 4.6 (browser-use) **(new)** | Anthropic | [45.2%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 5 | Claude Opus 4.6 CUA **(new)** | Anthropic | [36.3%](https://arxiv.org/abs/2604.09937) |
 
 [See all 11 entries →](https://leaderboard.steel.dev/leaderboards/healthadminbench)
 
@@ -162,13 +162,13 @@ Browser agents · Agent scope · 11 entries tracked
 
 Browser agents · Agent scope · 22 entries tracked
 
-| Rank | System                               | Organization             | Score                                                              |
-| ---: | ------------------------------------ | ------------------------ | ------------------------------------------------------------------ |
-|    1 | Browser Use Cloud (bu-max) **(new)** | Browser-Use              | [97.0%](https://browser-use.com/posts/online-mind2web-benchmark)   |
-|    2 | GPT-5.4 Native Computer Use          | OpenAI                   | [93.0%](https://openai.com/index/introducing-gpt-5-4/)             |
-|    3 | ABP + Claude Opus 4.6                | theredsix                | [90.53%](https://github.com/theredsix/abp-online-mind2web-results) |
-|    4 | TinyFish                             | TinyFish AI              | [90.0%](https://www.tinyfish.ai/blog/mind2web)                     |
-|    5 | UI-TARS-2                            | ByteDance / VLM-Research | [88.2%](https://arxiv.org/abs/2509.02544)                          |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Browser Use Cloud (bu-max) **(new)** | Browser-Use | [97.0%](https://browser-use.com/posts/online-mind2web-benchmark) |
+| 2 | GPT-5.4 Native Computer Use | OpenAI | [93.0%](https://openai.com/index/introducing-gpt-5-4/) |
+| 3 | ABP + Claude Opus 4.6 | theredsix | [90.53%](https://github.com/theredsix/abp-online-mind2web-results) |
+| 4 | TinyFish | TinyFish AI | [90.0%](https://www.tinyfish.ai/blog/mind2web) |
+| 5 | UI-TARS-2 | ByteDance / VLM-Research | [88.2%](https://arxiv.org/abs/2509.02544) |
 
 [See all 22 entries →](https://leaderboard.steel.dev/leaderboards/online-mind2web)
 
@@ -178,13 +178,13 @@ Browser agents · Agent scope · 22 entries tracked
 
 Model evals / reasoning · Model scope · 12 entries tracked
 
-| Rank | System         | Organization | Score                                                                  |
-| ---: | -------------- | ------------ | ---------------------------------------------------------------------- |
-|    1 | Step-3.5-Flash | StepFun      | [88.2%](https://arxiv.org/abs/2602.10604)                              |
-|    2 | GLM-4.7        | Z.ai         | [87.4%](https://docs.z.ai/guides/llm/glm-4.7)                          |
-|    3 | MiMo-V2-Flash  | Xiaomi       | [80.3%](https://arxiv.org/abs/2601.02780)                              |
-|    4 | GLM-4.7-Flash  | Z.ai         | [79.5%](https://inference-docs.cerebras.ai/resources/glm-47-migration) |
-|    5 | MiniMax M2     | MiniMax      | [77.2%](https://github.com/MiniMax-AI/MiniMax-M2)                      |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Step-3.5-Flash | StepFun | [88.2%](https://arxiv.org/abs/2602.10604) |
+| 2 | GLM-4.7 | Z.ai | [87.4%](https://docs.z.ai/guides/llm/glm-4.7) |
+| 3 | MiMo-V2-Flash | Xiaomi | [80.3%](https://arxiv.org/abs/2601.02780) |
+| 4 | GLM-4.7-Flash | Z.ai | [79.5%](https://inference-docs.cerebras.ai/resources/glm-47-migration) |
+| 5 | MiniMax M2 | MiniMax | [77.2%](https://github.com/MiniMax-AI/MiniMax-M2) |
 
 [See all 12 entries →](https://leaderboard.steel.dev/leaderboards/tau-bench)
 
@@ -194,13 +194,13 @@ Model evals / reasoning · Model scope · 12 entries tracked
 
 Model evals / reasoning · Model scope · 10 entries tracked
 
-| Rank | System                          | Organization        | Score                                     |
-| ---: | ------------------------------- | ------------------- | ----------------------------------------- |
-|    1 | AgentRL w/ Qwen2.5-32B-Instruct | Tsinghua University | [70.4%](https://arxiv.org/abs/2510.04206) |
-|    2 | AgentRL w/ Qwen2.5-14B-Instruct | Tsinghua University | [67.7%](https://arxiv.org/abs/2510.04206) |
-|    3 | AgentRL w/ GLM-4-9B-0414        | Tsinghua University | [65.0%](https://arxiv.org/abs/2510.04206) |
-|    4 | AgentRL w/ Qwen2.5-7B-Instruct  | Tsinghua University | [62.0%](https://arxiv.org/abs/2510.04206) |
-|    5 | AgentRL w/ Qwen2.5-3B-Instruct  | Tsinghua University | [60.0%](https://arxiv.org/abs/2510.04206) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | AgentRL w/ Qwen2.5-32B-Instruct | Tsinghua University | [70.4%](https://arxiv.org/abs/2510.04206) |
+| 2 | AgentRL w/ Qwen2.5-14B-Instruct | Tsinghua University | [67.7%](https://arxiv.org/abs/2510.04206) |
+| 3 | AgentRL w/ GLM-4-9B-0414 | Tsinghua University | [65.0%](https://arxiv.org/abs/2510.04206) |
+| 4 | AgentRL w/ Qwen2.5-7B-Instruct | Tsinghua University | [62.0%](https://arxiv.org/abs/2510.04206) |
+| 5 | AgentRL w/ Qwen2.5-3B-Instruct | Tsinghua University | [60.0%](https://arxiv.org/abs/2510.04206) |
 
 [See all 10 entries →](https://leaderboard.steel.dev/leaderboards/agentbench)
 

--- a/src/data/webvoyager.json
+++ b/src/data/webvoyager.json
@@ -2,6 +2,18 @@
   "webvoyager": [
     {
       "rank": 1,
+      "systemName": "browser-control (Fable 5)",
+      "organization": "browser-control",
+      "scoreDisplay": "99.19%",
+      "scoreValue": 99.19,
+      "sourceUrl": "https://github.com/omxyz/webvoyager",
+      "repoUrl": "https://github.com/keon/browser-control",
+      "notesShort": "Shell-native CDP harness driving Fable 5; 610/615 tasks, GPT-5.5 Alumnium-vanilla judge. Self-reported.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 2,
       "systemName": "Alumnium",
       "organization": "Alumnium",
       "scoreDisplay": "98.5%",
@@ -13,7 +25,7 @@
       "isNew": true
     },
     {
-      "rank": 2,
+      "rank": 3,
       "systemName": "Surfer 2",
       "organization": "H Company",
       "scoreDisplay": "97.1%",
@@ -23,7 +35,7 @@
       "reportedAt": "2025-10"
     },
     {
-      "rank": 3,
+      "rank": 4,
       "systemName": "Magnitude",
       "organization": "Magnitude",
       "scoreDisplay": "93.9%",
@@ -34,7 +46,7 @@
       "reportedAt": "2025-07"
     },
     {
-      "rank": 4,
+      "rank": 5,
       "systemName": "Surfer-H + Holo1",
       "organization": "H Company",
       "scoreDisplay": "92.2%",
@@ -45,7 +57,19 @@
       "reportedAt": "2025-06"
     },
     {
-      "rank": 5,
+      "rank": 6,
+      "systemName": "browser-control (Opus 4.8)",
+      "organization": "browser-control",
+      "scoreDisplay": "90.41%",
+      "scoreValue": 90.41,
+      "sourceUrl": "https://github.com/omxyz/webvoyager",
+      "repoUrl": "https://github.com/keon/browser-control",
+      "notesShort": "Shell-native CDP harness driving Claude Opus 4.8; 556/615 tasks, GPT-5.5 Alumnium-vanilla judge. Self-reported.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 7,
       "systemName": "Browserable",
       "organization": "Browserable",
       "scoreDisplay": "90.4%",
@@ -56,7 +80,7 @@
       "reportedAt": "2025-04"
     },
     {
-      "rank": 6,
+      "rank": 8,
       "systemName": "Browser Use",
       "organization": "Browser Use",
       "scoreDisplay": "89.1%",
@@ -67,7 +91,7 @@
       "reportedAt": "2024-12"
     },
     {
-      "rank": 7,
+      "rank": 9,
       "systemName": "GLM-5V-Turbo",
       "organization": "Z.ai",
       "scoreDisplay": "88.5%",
@@ -78,7 +102,7 @@
       "isNew": true
     },
     {
-      "rank": 8,
+      "rank": 10,
       "systemName": "Agent Kura",
       "organization": "Kura",
       "scoreDisplay": "87.0%",
@@ -88,7 +112,7 @@
       "reportedAt": "2024-11"
     },
     {
-      "rank": 8,
+      "rank": 10,
       "systemName": "Operator",
       "organization": "OpenAI",
       "scoreDisplay": "87%",
@@ -98,7 +122,7 @@
       "reportedAt": "2025-01"
     },
     {
-      "rank": 10,
+      "rank": 12,
       "systemName": "Notte",
       "organization": "Notte",
       "scoreDisplay": "86.2%",
@@ -109,7 +133,7 @@
       "reportedAt": "2025-04"
     },
     {
-      "rank": 11,
+      "rank": 13,
       "systemName": "Skyvern 2.0",
       "organization": "Skyvern",
       "scoreDisplay": "85.85%",
@@ -120,7 +144,7 @@
       "reportedAt": "2025-01"
     },
     {
-      "rank": 12,
+      "rank": 14,
       "systemName": "Project Mariner",
       "organization": "Google",
       "scoreDisplay": "83.5%",
@@ -130,7 +154,7 @@
       "reportedAt": "2024-12"
     },
     {
-      "rank": 13,
+      "rank": 15,
       "systemName": "Agent-E",
       "organization": "Emergence AI",
       "scoreDisplay": "73.2%",
@@ -141,7 +165,7 @@
       "reportedAt": "2024-07"
     },
     {
-      "rank": 14,
+      "rank": 16,
       "systemName": "WebSight",
       "organization": "Academic Research",
       "scoreDisplay": "68%",
@@ -151,7 +175,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 15,
+      "rank": 17,
       "systemName": "Runner H 0.1",
       "organization": "H Company",
       "scoreDisplay": "67%",
@@ -161,7 +185,7 @@
       "reportedAt": "2025-03"
     },
     {
-      "rank": 16,
+      "rank": 18,
       "systemName": "WebVoyager",
       "organization": "Academic Research",
       "scoreDisplay": "59.1%",
@@ -172,7 +196,7 @@
       "reportedAt": "2024-01"
     },
     {
-      "rank": 17,
+      "rank": 19,
       "systemName": "Anthropic Computer Use 3.5",
       "organization": "Anthropic",
       "scoreDisplay": "56.0%",
@@ -182,7 +206,7 @@
       "reportedAt": "2024-11"
     },
     {
-      "rank": 18,
+      "rank": 20,
       "systemName": "WILBUR",
       "organization": "Bardeen / UC Berkeley",
       "scoreDisplay": "53%",
@@ -192,7 +216,7 @@
       "reportedAt": "2024-04"
     },
     {
-      "rank": 19,
+      "rank": 21,
       "systemName": "GPT-4 (All Tools)",
       "organization": "OpenAI",
       "scoreDisplay": "30.8%",


### PR DESCRIPTION
I got lucky and was able to experiment with fable-5 before it was cut off.
Adds two WebVoyager runs of **browser-control** — a small, shell-native CDP harness for coding agents ([keon/browser-control](https://github.com/keon/browser-control)).

| Rank | System | Score | Tasks |
| ---: | --- | --- | --- |
| 1 | browser-control (Fable 5) | 99.19% | 610/615 |
| 6 | browser-control (Opus 4.8) | 90.41% | 556/615 |

### Methodology
- **Judge:** GPT-5.5, Alumnium-vanilla policy (screenshot + response → `SUCCESS`/`NOT SUCCESS`), matching the Alumnium entry's evaluation style.
- **Scope:** 615 tasks = the local WebVoyager 643 minus the 24-task Alumnium-removed set minus 4 currently-impossible tasks.
- Full run & eval harness and artifacts, per-task evidence, judge outputs, and score reports are public at [omxyz/webvoyager](https://github.com/omxyz/webvoyager).

### Notes
- Re-ranked the file with competition ranking (the 87.0% Agent Kura / Operator tie stays at rank 10, next is 12).
- `README.md` regenerated via `npm run update-readme`.
- Both runs use the same harness and differ only in the driving model.

Happy to adjust framing, scope notes, or placement to fit the leaderboard's conventions.