### PR TITLE
feat(leaderboard): add DRACO deep research benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The tables below show the current top entries on each tracked benchmark. Each se
 
 Browser agents · Agent scope · 19 entries tracked
 
-| Rank | System             | Organization | Score                                                          |
-| ---: | ------------------ | ------------ | -------------------------------------------------------------- |
-|    1 | Alumnium **(new)** | Alumnium     | [98.5%](https://alumnium.ai/blog/webvoyager-benchmark/)        |
-|    2 | Surfer 2           | H Company    | [97.1%](https://hcompany.ai/surfer-2)                          |
-|    3 | Magnitude          | Magnitude    | [93.9%](https://magnitude.run/webvoyager)                      |
-|    4 | Surfer-H + Holo1   | H Company    | [92.2%](https://arxiv.org/pdf/2506.02865)                      |
-|    5 | Browserable        | Browserable  | [90.4%](https://www.browserable.ai/blog/web-voyager-benchmark) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Alumnium **(new)** | Alumnium | [98.5%](https://alumnium.ai/blog/webvoyager-benchmark/) |
+| 2 | Surfer 2 | H Company | [97.1%](https://hcompany.ai/surfer-2) |
+| 3 | Magnitude | Magnitude | [93.9%](https://magnitude.run/webvoyager) |
+| 4 | Surfer-H + Holo1 | H Company | [92.2%](https://arxiv.org/pdf/2506.02865) |
+| 5 | Browserable | Browserable | [90.4%](https://www.browserable.ai/blog/web-voyager-benchmark) |
 
 [See all 19 entries →](https://leaderboard.steel.dev/leaderboards/webvoyager)
 
@@ -32,17 +32,33 @@ Browser agents · Agent scope · 19 entries tracked
 
 ### [BrowseComp](https://leaderboard.steel.dev/leaderboards/browsecomp)
 
-Research/search · Mixed scope · 82 entries tracked
+Research/search · Mixed scope · 83 entries tracked
 
-| Rank | System                | Organization | Score                                                                                                                                                                               |
-| ---: | --------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-|    1 | GPT-5.5 Pro           | OpenAI       | [90.1%](https://openai.com/index/introducing-gpt-5-5/)                                                                                                                              |
-|    2 | GPT-5.4 Pro           | OpenAI       | [89.3%](https://openai.com/index/introducing-gpt-5-5/)                                                                                                                              |
-|    3 | MiroThinker-H1        | MiroMind     | [88.2%](https://www.prnewswire.com/news-releases/miromind-team-unveils-mirothinker-1-7--mirothinker-h1-a-new-era-of-verification-centric-heavy-duty-research-agents-302714500.html) |
-|    4 | Claude Mythos Preview | Anthropic    | [86.9%](https://www.anthropic.com/glasswing)                                                                                                                                        |
-|    5 | Kimi K2.6             | Moonshot AI  | [86.3%](https://www.kimi.com/blog/kimi-k2-6)                                                                                                                                        |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | GPT-5.5 Pro | OpenAI | [90.1%](https://openai.com/index/introducing-gpt-5-5/) |
+| 2 | GPT-5.4 Pro | OpenAI | [89.3%](https://openai.com/index/introducing-gpt-5-5/) |
+| 3 | MiroThinker-H1 | MiroMind | [88.2%](https://www.prnewswire.com/news-releases/miromind-team-unveils-mirothinker-1-7--mirothinker-h1-a-new-era-of-verification-centric-heavy-duty-research-agents-302714500.html) |
+| 4 | Claude Mythos 5 **(new)** | Anthropic | [88.0%](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) |
+| 5 | Claude Mythos Preview | Anthropic | [86.9%](https://www.anthropic.com/glasswing) |
 
-[See all 82 entries →](https://leaderboard.steel.dev/leaderboards/browsecomp)
+[See all 83 entries →](https://leaderboard.steel.dev/leaderboards/browsecomp)
+
+---
+
+### [DRACO](https://leaderboard.steel.dev/leaderboards/draco)
+
+Research/search · Mixed scope · 13 entries tracked
+
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Mythos 5 **(new)** | Anthropic | [86.4%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 2 | Claude Mythos Preview | Anthropic | [83.6%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 3 | Claude Opus 4.8 | Anthropic | [80.4%](https://www-cdn.anthropic.com/0f0c97ad20d8005706296bd92aa1c27c6b2f4f61/Claude%20Opus%204.8%20System%20Card.pdf) |
+| 4 | Claude Opus 4.7 | Anthropic | [77.7%](https://www-cdn.anthropic.com/037f06850df7fbe871e206dad004c3db5fd50340/Claude%20Opus%204.7%20System%20Card.pdf) |
+| 5 | MiniMax M3 **(new)** | MiniMax | [73.23%](https://www.minimax.io/blog/minimax-m3) |
+
+[See all 13 entries →](https://leaderboard.steel.dev/leaderboards/draco)
 
 ---
 
@@ -50,13 +66,13 @@ Research/search · Mixed scope · 82 entries tracked
 
 Browser agents · Agent scope · 49 entries tracked
 
-| Rank | System                    | Organization | Score                                                                                        |
-| ---: | ------------------------- | ------------ | -------------------------------------------------------------------------------------------- |
-|    1 | WebTactix (DeepSeek v3.2) | WebTactix    | [74.3%](https://paper-submission-anoymous.github.io/webtactix_introduction/)                 |
-|    2 | OpAgent                   | CodeFuse AI  | [71.6%](https://github.com/codefuse-ai/OpAgent)                                              |
-|    3 | ColorBrowserAgent         | MadeAgents   | [71.2%](https://arxiv.org/abs/2601.07262)                                                    |
-|    4 | Claude Code + GBOX MCP    | GBOX AI      | [68.0%](https://github.com/babelcloud/webarena/blob/main/gbox/report.md)                     |
-|    5 | DeepSky Agent             | DeepSky      | [66.9%](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | WebTactix (DeepSeek v3.2) | WebTactix | [74.3%](https://paper-submission-anoymous.github.io/webtactix_introduction/) |
+| 2 | OpAgent | CodeFuse AI | [71.6%](https://github.com/codefuse-ai/OpAgent) |
+| 3 | ColorBrowserAgent | MadeAgents | [71.2%](https://arxiv.org/abs/2601.07262) |
+| 4 | Claude Code + GBOX MCP | GBOX AI | [68.0%](https://github.com/babelcloud/webarena/blob/main/gbox/report.md) |
+| 5 | DeepSky Agent | DeepSky | [66.9%](https://docs.google.com/spreadsheets/d/1M801lEpBbKSNwP-vDBkC_pF7LdyGU1f_ufZb_NWNBZQ) |
 
 [See all 49 entries →](https://leaderboard.steel.dev/leaderboards/webarena)
 
@@ -64,17 +80,17 @@ Browser agents · Agent scope · 49 entries tracked
 
 ### [SWE-bench Verified](https://leaderboard.steel.dev/leaderboards/swe-bench-verified)
 
-Coding · Model scope · 16 entries tracked
+Coding · Model scope · 18 entries tracked
 
-| Rank | System                    | Organization | Score                                                                                            |
-| ---: | ------------------------- | ------------ | ------------------------------------------------------------------------------------------------ |
-|    1 | Claude Mythos             | Anthropic    | [93.9%](https://www.mindstudio.ai/blog/claude-mythos-benchmark-results-swe-bench-agentic-coding) |
-|    2 | Claude Opus 4.8 **(new)** | Anthropic    | [88.6%](https://www.anthropic.com/news/claude-opus-4-8)                                          |
-|    3 | Claude Opus 4.7           | Anthropic    | [87.6%](https://www.anthropic.com/news/claude-opus-4-7)                                          |
-|    4 | Claude Opus 4.5           | Anthropic    | [80.9%](https://www.anthropic.com/news/claude-opus-4-5)                                          |
-|    5 | Claude Opus 4.6           | Anthropic    | [80.8%](https://www.anthropic.com/news/claude-opus-4-6)                                          |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Mythos 5 **(new)** | Anthropic | [95.5%](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) |
+| 2 | Claude Fable 5 **(new)** | Anthropic | [95.0%](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) |
+| 3 | Claude Mythos Preview | Anthropic | [93.9%](https://www.mindstudio.ai/blog/claude-mythos-benchmark-results-swe-bench-agentic-coding) |
+| 4 | Claude Opus 4.8 **(new)** | Anthropic | [88.6%](https://www.anthropic.com/news/claude-opus-4-8) |
+| 5 | Claude Opus 4.7 | Anthropic | [87.6%](https://www.anthropic.com/news/claude-opus-4-7) |
 
-[See all 16 entries →](https://leaderboard.steel.dev/leaderboards/swe-bench-verified)
+[See all 18 entries →](https://leaderboard.steel.dev/leaderboards/swe-bench-verified)
 
 ---
 
@@ -82,13 +98,13 @@ Coding · Model scope · 16 entries tracked
 
 Coding · Model scope · 15 entries tracked
 
-| Rank | System                                   | Organization | Score                                          |
-| ---: | ---------------------------------------- | ------------ | ---------------------------------------------- |
-|    1 | gpt-5 (high)                             | OpenAI       | [88.0%](https://aider.chat/docs/leaderboards/) |
-|    2 | gpt-5 (medium)                           | OpenAI       | [86.7%](https://aider.chat/docs/leaderboards/) |
-|    3 | o3-pro (high)                            | OpenAI       | [84.9%](https://aider.chat/docs/leaderboards/) |
-|    4 | gemini-2.5-pro-preview-06-05 (32k think) | Google       | [83.1%](https://aider.chat/docs/leaderboards/) |
-|    5 | o3 (high)                                | OpenAI       | [81.3%](https://aider.chat/docs/leaderboards/) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | gpt-5 (high) | OpenAI | [88.0%](https://aider.chat/docs/leaderboards/) |
+| 2 | gpt-5 (medium) | OpenAI | [86.7%](https://aider.chat/docs/leaderboards/) |
+| 3 | o3-pro (high) | OpenAI | [84.9%](https://aider.chat/docs/leaderboards/) |
+| 4 | gemini-2.5-pro-preview-06-05 (32k think) | Google | [83.1%](https://aider.chat/docs/leaderboards/) |
+| 5 | o3 (high) | OpenAI | [81.3%](https://aider.chat/docs/leaderboards/) |
 
 [See all 15 entries →](https://leaderboard.steel.dev/leaderboards/aider)
 
@@ -96,17 +112,17 @@ Coding · Model scope · 15 entries tracked
 
 ### [OSWorld](https://leaderboard.steel.dev/leaderboards/osworld)
 
-Computer use · Agent scope · 17 entries tracked
+Computer use · Agent scope · 19 entries tracked
 
-| Rank | System                    | Organization   | Score                                                   |
-| ---: | ------------------------- | -------------- | ------------------------------------------------------- |
-|    1 | Claude Opus 4.8 **(new)** | Anthropic      | [83.4%](https://www.anthropic.com/news/claude-opus-4-8) |
-|    2 | Mythos Preview **(new)**  | Anthropic      | [79.6%](https://www.anthropic.com/glasswing)            |
-|    3 | OSAgent                   | TheAGI Company | [76.26%](https://www.theagi.company/blog/osworld)       |
-|    4 | GPT-5.4 **(new)**         | OpenAI         | [75.0%](https://openai.com/index/introducing-gpt-5-4/)  |
-|    5 | Claude Opus 4.6           | Anthropic      | [72.7%](https://www.anthropic.com/glasswing)            |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Mythos Preview **(new)** | Anthropic | [85.4%](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) |
+| 2 | Claude Mythos 5 **(new)** | Anthropic | [85.0%](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) |
+| 2 | Claude Fable 5 **(new)** | Anthropic | [85.0%](https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf) |
+| 4 | Claude Opus 4.8 **(new)** | Anthropic | [83.4%](https://www.anthropic.com/news/claude-opus-4-8) |
+| 5 | OSAgent | TheAGI Company | [76.26%](https://www.theagi.company/blog/osworld) |
 
-[See all 17 entries →](https://leaderboard.steel.dev/leaderboards/osworld)
+[See all 19 entries →](https://leaderboard.steel.dev/leaderboards/osworld)
 
 ---
 
@@ -114,13 +130,13 @@ Computer use · Agent scope · 17 entries tracked
 
 Model evals / reasoning · Agent scope · 21 entries tracked
 
-| Rank | System                             | Organization                 | Score                                                                              |
-| ---: | ---------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------- |
-|    1 | OPS-Agentic-Search **(new)**       | Alibaba Cloud                | [92.36%](https://gaia-benchmark-leaderboard.hf.space/ant_test)                     |
-|    1 | openJiuwen-deepagent **(new)**     | Suzhou AI Lab / Shuqian Tech | [92.36%](https://gitcode.com/openJiuwen/agent-store/tree/main/community/deepagent) |
-|    3 | openJiuwen-deepagent (GPT5/Gemini) | openJiuwen                   | [91.69%](https://gaia-benchmark-leaderboard.hf.space/ant_test)                     |
-|    4 | Lemon Agent                        | Lenovo CTO Org               | [91.36%](https://github.com/Open-Lemon/LemonAgent)                                 |
-|    5 | JoinAI V2.2                        | JoinAI-CMCC                  | [90.7%](https://gaia-benchmark-leaderboard.hf.space/ant_test)                      |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | OPS-Agentic-Search **(new)** | Alibaba Cloud | [92.36%](https://gaia-benchmark-leaderboard.hf.space/ant_test) |
+| 1 | openJiuwen-deepagent **(new)** | Suzhou AI Lab / Shuqian Tech | [92.36%](https://gitcode.com/openJiuwen/agent-store/tree/main/community/deepagent) |
+| 3 | openJiuwen-deepagent (GPT5/Gemini) | openJiuwen | [91.69%](https://gaia-benchmark-leaderboard.hf.space/ant_test) |
+| 4 | Lemon Agent | Lenovo CTO Org | [91.36%](https://github.com/Open-Lemon/LemonAgent) |
+| 5 | JoinAI V2.2 | JoinAI-CMCC | [90.7%](https://gaia-benchmark-leaderboard.hf.space/ant_test) |
 
 [See all 21 entries →](https://leaderboard.steel.dev/leaderboards/gaia)
 
@@ -130,13 +146,13 @@ Model evals / reasoning · Agent scope · 21 entries tracked
 
 Browser agents · Agent scope · 7 entries tracked
 
-| Rank | System            | Organization | Score                                     |
-| ---: | ----------------- | ------------ | ----------------------------------------- |
-|    1 | Claude Sonnet 4.6 | Anthropic    | [33.3%](https://arxiv.org/abs/2604.08523) |
-|    2 | GLM-5 **(new)**   | Z.ai         | [24.2%](https://arxiv.org/abs/2604.08523) |
-|    3 | Gemini 3 Flash    | Google       | [19.0%](https://arxiv.org/abs/2604.08523) |
-|    4 | Claude Haiku 4.5  | Anthropic    | [18.3%](https://arxiv.org/abs/2604.08523) |
-|    5 | GPT-5.4           | OpenAI       | [6.5%](https://arxiv.org/abs/2604.08523)  |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Sonnet 4.6 | Anthropic | [33.3%](https://arxiv.org/abs/2604.08523) |
+| 2 | GLM-5 **(new)** | Z.ai | [24.2%](https://arxiv.org/abs/2604.08523) |
+| 3 | Gemini 3 Flash | Google | [19.0%](https://arxiv.org/abs/2604.08523) |
+| 4 | Claude Haiku 4.5 | Anthropic | [18.3%](https://arxiv.org/abs/2604.08523) |
+| 5 | GPT-5.4 | OpenAI | [6.5%](https://arxiv.org/abs/2604.08523) |
 
 [See all 7 entries →](https://leaderboard.steel.dev/leaderboards/clawbench)
 
@@ -146,13 +162,13 @@ Browser agents · Agent scope · 7 entries tracked
 
 Browser agents · Agent scope · 11 entries tracked
 
-| Rank | System                                        | Organization | Score                                                                  |
-| ---: | --------------------------------------------- | ------------ | ---------------------------------------------------------------------- |
-|    1 | Claude Mythos 5 (browser-use) **(new)**       | Anthropic    | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    1 | Claude Opus 4.8 (browser-use) **(new)**       | Anthropic    | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    3 | Claude Mythos Preview (browser-use) **(new)** | Anthropic    | [47.4%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    4 | Claude Sonnet 4.6 (browser-use) **(new)**     | Anthropic    | [45.2%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
-|    5 | Claude Opus 4.6 CUA **(new)**                 | Anthropic    | [36.3%](https://arxiv.org/abs/2604.09937)                              |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Claude Mythos 5 (browser-use) **(new)** | Anthropic | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 1 | Claude Opus 4.8 (browser-use) **(new)** | Anthropic | [51.9%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 3 | Claude Mythos Preview (browser-use) **(new)** | Anthropic | [47.4%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 4 | Claude Sonnet 4.6 (browser-use) **(new)** | Anthropic | [45.2%](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) |
+| 5 | Claude Opus 4.6 CUA **(new)** | Anthropic | [36.3%](https://arxiv.org/abs/2604.09937) |
 
 [See all 11 entries →](https://leaderboard.steel.dev/leaderboards/healthadminbench)
 
@@ -162,13 +178,13 @@ Browser agents · Agent scope · 11 entries tracked
 
 Browser agents · Agent scope · 22 entries tracked
 
-| Rank | System                               | Organization             | Score                                                              |
-| ---: | ------------------------------------ | ------------------------ | ------------------------------------------------------------------ |
-|    1 | Browser Use Cloud (bu-max) **(new)** | Browser-Use              | [97.0%](https://browser-use.com/posts/online-mind2web-benchmark)   |
-|    2 | GPT-5.4 Native Computer Use          | OpenAI                   | [93.0%](https://openai.com/index/introducing-gpt-5-4/)             |
-|    3 | ABP + Claude Opus 4.6                | theredsix                | [90.53%](https://github.com/theredsix/abp-online-mind2web-results) |
-|    4 | TinyFish                             | TinyFish AI              | [90.0%](https://www.tinyfish.ai/blog/mind2web)                     |
-|    5 | UI-TARS-2                            | ByteDance / VLM-Research | [88.2%](https://arxiv.org/abs/2509.02544)                          |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Browser Use Cloud (bu-max) **(new)** | Browser-Use | [97.0%](https://browser-use.com/posts/online-mind2web-benchmark) |
+| 2 | GPT-5.4 Native Computer Use | OpenAI | [93.0%](https://openai.com/index/introducing-gpt-5-4/) |
+| 3 | ABP + Claude Opus 4.6 | theredsix | [90.53%](https://github.com/theredsix/abp-online-mind2web-results) |
+| 4 | TinyFish | TinyFish AI | [90.0%](https://www.tinyfish.ai/blog/mind2web) |
+| 5 | UI-TARS-2 | ByteDance / VLM-Research | [88.2%](https://arxiv.org/abs/2509.02544) |
 
 [See all 22 entries →](https://leaderboard.steel.dev/leaderboards/online-mind2web)
 
@@ -178,13 +194,13 @@ Browser agents · Agent scope · 22 entries tracked
 
 Model evals / reasoning · Model scope · 12 entries tracked
 
-| Rank | System         | Organization | Score                                                                  |
-| ---: | -------------- | ------------ | ---------------------------------------------------------------------- |
-|    1 | Step-3.5-Flash | StepFun      | [88.2%](https://arxiv.org/abs/2602.10604)                              |
-|    2 | GLM-4.7        | Z.ai         | [87.4%](https://docs.z.ai/guides/llm/glm-4.7)                          |
-|    3 | MiMo-V2-Flash  | Xiaomi       | [80.3%](https://arxiv.org/abs/2601.02780)                              |
-|    4 | GLM-4.7-Flash  | Z.ai         | [79.5%](https://inference-docs.cerebras.ai/resources/glm-47-migration) |
-|    5 | MiniMax M2     | MiniMax      | [77.2%](https://github.com/MiniMax-AI/MiniMax-M2)                      |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | Step-3.5-Flash | StepFun | [88.2%](https://arxiv.org/abs/2602.10604) |
+| 2 | GLM-4.7 | Z.ai | [87.4%](https://docs.z.ai/guides/llm/glm-4.7) |
+| 3 | MiMo-V2-Flash | Xiaomi | [80.3%](https://arxiv.org/abs/2601.02780) |
+| 4 | GLM-4.7-Flash | Z.ai | [79.5%](https://inference-docs.cerebras.ai/resources/glm-47-migration) |
+| 5 | MiniMax M2 | MiniMax | [77.2%](https://github.com/MiniMax-AI/MiniMax-M2) |
 
 [See all 12 entries →](https://leaderboard.steel.dev/leaderboards/tau-bench)
 
@@ -194,13 +210,13 @@ Model evals / reasoning · Model scope · 12 entries tracked
 
 Model evals / reasoning · Model scope · 10 entries tracked
 
-| Rank | System                          | Organization        | Score                                     |
-| ---: | ------------------------------- | ------------------- | ----------------------------------------- |
-|    1 | AgentRL w/ Qwen2.5-32B-Instruct | Tsinghua University | [70.4%](https://arxiv.org/abs/2510.04206) |
-|    2 | AgentRL w/ Qwen2.5-14B-Instruct | Tsinghua University | [67.7%](https://arxiv.org/abs/2510.04206) |
-|    3 | AgentRL w/ GLM-4-9B-0414        | Tsinghua University | [65.0%](https://arxiv.org/abs/2510.04206) |
-|    4 | AgentRL w/ Qwen2.5-7B-Instruct  | Tsinghua University | [62.0%](https://arxiv.org/abs/2510.04206) |
-|    5 | AgentRL w/ Qwen2.5-3B-Instruct  | Tsinghua University | [60.0%](https://arxiv.org/abs/2510.04206) |
+| Rank | System | Organization | Score |
+| ---: | ------ | ------------ | ----- |
+| 1 | AgentRL w/ Qwen2.5-32B-Instruct | Tsinghua University | [70.4%](https://arxiv.org/abs/2510.04206) |
+| 2 | AgentRL w/ Qwen2.5-14B-Instruct | Tsinghua University | [67.7%](https://arxiv.org/abs/2510.04206) |
+| 3 | AgentRL w/ GLM-4-9B-0414 | Tsinghua University | [65.0%](https://arxiv.org/abs/2510.04206) |
+| 4 | AgentRL w/ Qwen2.5-7B-Instruct | Tsinghua University | [62.0%](https://arxiv.org/abs/2510.04206) |
+| 5 | AgentRL w/ Qwen2.5-3B-Instruct | Tsinghua University | [60.0%](https://arxiv.org/abs/2510.04206) |
 
 [See all 10 entries →](https://leaderboard.steel.dev/leaderboards/agentbench)
 

--- a/src/data/browsecomp.json
+++ b/src/data/browsecomp.json
@@ -33,6 +33,17 @@
     },
     {
       "rank": 4,
+      "systemName": "Claude Mythos 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "88.0%",
+      "scoreValue": 88.0,
+      "sourceUrl": "https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf",
+      "notesShort": "Single-agent; web search, web fetch, programmatic tool calling, and code execution; adaptive thinking at max effort with compaction up to a 10M-token limit (async multi-agent configuration reaches 93.3%). Self-reported in the Claude 5 system card.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 5,
       "systemName": "Claude Mythos Preview",
       "organization": "Anthropic",
       "scoreDisplay": "86.9%",
@@ -42,7 +53,7 @@
       "reportedAt": "2026-04-07"
     },
     {
-      "rank": 5,
+      "rank": 6,
       "systemName": "Kimi K2.6",
       "organization": "Moonshot AI",
       "scoreDisplay": "86.3%",
@@ -53,7 +64,7 @@
       "reportedAt": "2026-04-20"
     },
     {
-      "rank": 6,
+      "rank": 7,
       "systemName": "Gemini 3.1 Pro",
       "organization": "Google",
       "scoreDisplay": "85.9%",
@@ -63,7 +74,7 @@
       "reportedAt": "2026-02-19"
     },
     {
-      "rank": 7,
+      "rank": 8,
       "systemName": "GPT-5.5",
       "organization": "OpenAI",
       "scoreDisplay": "84.4%",
@@ -73,7 +84,7 @@
       "reportedAt": "2026-04"
     },
     {
-      "rank": 8,
+      "rank": 9,
       "systemName": "Claude Opus 4.8",
       "organization": "Anthropic",
       "scoreDisplay": "84.3%",
@@ -84,7 +95,7 @@
       "isNew": true
     },
     {
-      "rank": 9,
+      "rank": 10,
       "systemName": "Claude Opus 4.6",
       "organization": "Anthropic",
       "scoreDisplay": "83.7%",
@@ -94,7 +105,7 @@
       "reportedAt": "2026-04-07"
     },
     {
-      "rank": 10,
+      "rank": 11,
       "systemName": "DeepSeek-V4-Pro-Max",
       "organization": "DeepSeek",
       "scoreDisplay": "83.4%",
@@ -105,7 +116,7 @@
       "reportedAt": "2026-04-24"
     },
     {
-      "rank": 11,
+      "rank": 12,
       "systemName": "GPT-5.4",
       "organization": "OpenAI",
       "scoreDisplay": "82.7%",
@@ -115,7 +126,7 @@
       "reportedAt": "2026-03-05"
     },
     {
-      "rank": 12,
+      "rank": 13,
       "systemName": "Claude Opus 4.7",
       "organization": "Anthropic",
       "scoreDisplay": "79.3%",
@@ -125,7 +136,7 @@
       "reportedAt": "2026-04-16"
     },
     {
-      "rank": 12,
+      "rank": 13,
       "systemName": "GLM-5.1",
       "organization": "Zhipu AI",
       "scoreDisplay": "79.3%",
@@ -136,7 +147,7 @@
       "reportedAt": "2026-04"
     },
     {
-      "rank": 14,
+      "rank": 15,
       "systemName": "Qwen3.5-397B-A17B",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "78.6%",
@@ -147,7 +158,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 15,
+      "rank": 16,
       "systemName": "Kimi K2.5",
       "organization": "Moonshot AI",
       "scoreDisplay": "78.4%",
@@ -158,7 +169,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 16,
+      "rank": 17,
       "systemName": "GPT-5.2 Pro",
       "organization": "OpenAI",
       "scoreDisplay": "77.9%",
@@ -168,7 +179,7 @@
       "reportedAt": "2025-12-11"
     },
     {
-      "rank": 17,
+      "rank": 18,
       "systemName": "GPT-5.3-Codex",
       "organization": "OpenAI",
       "scoreDisplay": "77.3%",
@@ -178,7 +189,7 @@
       "reportedAt": "2026-03-05"
     },
     {
-      "rank": 17,
+      "rank": 18,
       "systemName": "Seed 2.0 Pro",
       "organization": "ByteDance",
       "scoreDisplay": "77.3%",
@@ -188,7 +199,7 @@
       "reportedAt": "2026-02-15"
     },
     {
-      "rank": 19,
+      "rank": 20,
       "systemName": "MiniMax M2.5",
       "organization": "MiniMax",
       "scoreDisplay": "76.3%",
@@ -199,7 +210,7 @@
       "reportedAt": "2026-04"
     },
     {
-      "rank": 20,
+      "rank": 21,
       "systemName": "GLM-5",
       "organization": "Zhipu AI",
       "scoreDisplay": "75.9%",
@@ -210,7 +221,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 21,
+      "rank": 22,
       "systemName": "Claude Sonnet 4.6",
       "organization": "Anthropic",
       "scoreDisplay": "74.7%",
@@ -220,7 +231,7 @@
       "reportedAt": "2026-02-17"
     },
     {
-      "rank": 22,
+      "rank": 23,
       "systemName": "DeepSeek-V4-Flash-Max",
       "organization": "DeepSeek",
       "scoreDisplay": "73.2%",
@@ -231,7 +242,7 @@
       "reportedAt": "2026-04-24"
     },
     {
-      "rank": 23,
+      "rank": 24,
       "systemName": "LongCat-Flash-Thinking-2601",
       "organization": "Meituan",
       "scoreDisplay": "73.1%",
@@ -242,7 +253,7 @@
       "reportedAt": "2026-01"
     },
     {
-      "rank": 24,
+      "rank": 25,
       "systemName": "Step-3.5-Flash",
       "organization": "StepFun",
       "scoreDisplay": "69.0%",
@@ -252,7 +263,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 25,
+      "rank": 26,
       "systemName": "GLM-4.7",
       "organization": "Zhipu AI",
       "scoreDisplay": "67.5%",
@@ -263,7 +274,7 @@
       "reportedAt": "2025-12"
     },
     {
-      "rank": 26,
+      "rank": 27,
       "systemName": "GPT-5.2",
       "organization": "OpenAI",
       "scoreDisplay": "65.8%",
@@ -273,7 +284,7 @@
       "reportedAt": "2025-12-11"
     },
     {
-      "rank": 27,
+      "rank": 28,
       "systemName": "Qwen3.5-122B-A10B",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "63.8%",
@@ -284,7 +295,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 28,
+      "rank": 29,
       "systemName": "MiniMax M2.1",
       "organization": "MiniMax",
       "scoreDisplay": "62.0%",
@@ -294,7 +305,7 @@
       "reportedAt": "2025-12"
     },
     {
-      "rank": 29,
+      "rank": 30,
       "systemName": "LongSeeker",
       "organization": "Academic Research",
       "scoreDisplay": "61.5%",
@@ -305,7 +316,7 @@
       "isNew": true
     },
     {
-      "rank": 30,
+      "rank": 31,
       "systemName": "Qwen3.5-27B",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "61.0%",
@@ -316,7 +327,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 30,
+      "rank": 31,
       "systemName": "Qwen3.5-35B-A3B",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "61.0%",
@@ -327,7 +338,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 32,
+      "rank": 33,
       "systemName": "Kimi K2-Thinking-0905",
       "organization": "Moonshot AI",
       "scoreDisplay": "60.2%",
@@ -338,7 +349,7 @@
       "reportedAt": "2025-11"
     },
     {
-      "rank": 33,
+      "rank": 34,
       "systemName": "Gemini 3 Pro",
       "organization": "Google",
       "scoreDisplay": "59.2%",
@@ -348,7 +359,7 @@
       "reportedAt": "2026-02-19"
     },
     {
-      "rank": 34,
+      "rank": 35,
       "systemName": "MiMo-V2-Flash",
       "organization": "Xiaomi",
       "scoreDisplay": "58.3%",
@@ -359,7 +370,7 @@
       "reportedAt": "2026-01"
     },
     {
-      "rank": 35,
+      "rank": 36,
       "systemName": "Parallel Ultra8x",
       "organization": "Parallel",
       "scoreDisplay": "58.0%",
@@ -369,7 +380,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 36,
+      "rank": 37,
       "systemName": "Parallel Ultra4x",
       "organization": "Parallel",
       "scoreDisplay": "56.0%",
@@ -379,7 +390,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 37,
+      "rank": 38,
       "systemName": "GPT-5",
       "organization": "OpenAI",
       "scoreDisplay": "54.9%",
@@ -389,7 +400,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 38,
+      "rank": 39,
       "systemName": "Parallel Basic + GPT-5.4 harness",
       "organization": "Parallel",
       "scoreDisplay": "53.0%",
@@ -399,7 +410,7 @@
       "reportedAt": "2026-04-21"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "systemName": "o4-mini",
       "organization": "OpenAI",
       "scoreDisplay": "51.5%",
@@ -409,7 +420,7 @@
       "reportedAt": "2025-04-16"
     },
     {
-      "rank": 39,
+      "rank": 40,
       "systemName": "OpenAI Deep Research",
       "organization": "OpenAI",
       "scoreDisplay": "51.5%",
@@ -419,7 +430,7 @@
       "reportedAt": "2025-04-10"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "systemName": "DeepSeek-V3.2",
       "organization": "DeepSeek",
       "scoreDisplay": "51.4%",
@@ -430,7 +441,7 @@
       "reportedAt": "2025-12-01"
     },
     {
-      "rank": 41,
+      "rank": 42,
       "systemName": "DeepSeek-V3.2 (Thinking)",
       "organization": "DeepSeek",
       "scoreDisplay": "51.4%",
@@ -441,7 +452,7 @@
       "reportedAt": "2025-12-01"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "systemName": "Parallel Advanced + GPT-5.4 harness",
       "organization": "Parallel",
       "scoreDisplay": "51.0%",
@@ -451,7 +462,7 @@
       "reportedAt": "2026-04-21"
     },
     {
-      "rank": 43,
+      "rank": 44,
       "systemName": "Parallel Ultra2x",
       "organization": "Parallel",
       "scoreDisplay": "51.0%",
@@ -461,7 +472,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 45,
+      "rank": 46,
       "systemName": "o3",
       "organization": "OpenAI",
       "scoreDisplay": "49.7%",
@@ -471,7 +482,7 @@
       "reportedAt": "2025-04-16"
     },
     {
-      "rank": 46,
+      "rank": 47,
       "systemName": "Sarvam-105B",
       "organization": "Sarvam AI",
       "scoreDisplay": "49.5%",
@@ -482,7 +493,7 @@
       "reportedAt": "2026-03-06"
     },
     {
-      "rank": 47,
+      "rank": 48,
       "systemName": "SMTL",
       "organization": "Academic Research",
       "scoreDisplay": "48.6%",
@@ -492,7 +503,7 @@
       "reportedAt": "2026-02-27"
     },
     {
-      "rank": 48,
+      "rank": 49,
       "systemName": "MiroThinker v1.0-72B",
       "organization": "MiroMind",
       "scoreDisplay": "47.1%",
@@ -503,7 +514,7 @@
       "reportedAt": "2026-04-21"
     },
     {
-      "rank": 49,
+      "rank": 50,
       "systemName": "OpenSeeker-v2",
       "organization": "PolarSeeker",
       "scoreDisplay": "46.0%",
@@ -515,7 +526,7 @@
       "isNew": true
     },
     {
-      "rank": 49,
+      "rank": 50,
       "systemName": "WebAnchor-30B",
       "organization": "Academic Research",
       "scoreDisplay": "46.0%",
@@ -525,7 +536,7 @@
       "reportedAt": "2026-01-07"
     },
     {
-      "rank": 51,
+      "rank": 52,
       "systemName": "GLM-4.6",
       "organization": "Zhipu AI",
       "scoreDisplay": "45.1%",
@@ -536,7 +547,7 @@
       "reportedAt": "2025-10"
     },
     {
-      "rank": 52,
+      "rank": 53,
       "systemName": "Parallel Ultra",
       "organization": "Parallel",
       "scoreDisplay": "45.0%",
@@ -546,7 +557,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 53,
+      "rank": 54,
       "systemName": "Grok 4 Fast",
       "organization": "xAI",
       "scoreDisplay": "44.9%",
@@ -556,7 +567,7 @@
       "reportedAt": "2025-09-22"
     },
     {
-      "rank": 54,
+      "rank": 55,
       "systemName": "MiniMax M2",
       "organization": "MiniMax",
       "scoreDisplay": "44.0%",
@@ -567,7 +578,7 @@
       "reportedAt": "2025-10"
     },
     {
-      "rank": 55,
+      "rank": 56,
       "systemName": "Tongyi DeepResearch",
       "organization": "Alibaba Cloud / Tongyi Lab",
       "scoreDisplay": "43.4%",
@@ -578,7 +589,7 @@
       "reportedAt": "2025-09-16"
     },
     {
-      "rank": 56,
+      "rank": 57,
       "systemName": "GLM-4.7-Flash",
       "organization": "Zhipu AI",
       "scoreDisplay": "42.8%",
@@ -589,7 +600,7 @@
       "reportedAt": "2026-02"
     },
     {
-      "rank": 57,
+      "rank": 58,
       "systemName": "Tavily + GPT-5.4 harness",
       "organization": "Tavily",
       "scoreDisplay": "42.0%",
@@ -599,7 +610,7 @@
       "reportedAt": "2026-04-21"
     },
     {
-      "rank": 58,
+      "rank": 59,
       "systemName": "DeepSeek-V3.2-Exp",
       "organization": "DeepSeek",
       "scoreDisplay": "40.1%",
@@ -610,7 +621,7 @@
       "reportedAt": "2025-09-30"
     },
     {
-      "rank": 59,
+      "rank": 60,
       "systemName": "Exa + GPT-5.4 harness",
       "organization": "Exa",
       "scoreDisplay": "40.0%",
@@ -620,7 +631,7 @@
       "reportedAt": "2026-04-21"
     },
     {
-      "rank": 60,
+      "rank": 61,
       "systemName": "AgentFounder-30B",
       "organization": "Alibaba Cloud / Tongyi Lab",
       "scoreDisplay": "39.9%",
@@ -630,7 +641,7 @@
       "reportedAt": "2025-09-16"
     },
     {
-      "rank": 61,
+      "rank": 62,
       "systemName": "Sarvam-30B",
       "organization": "Sarvam AI",
       "scoreDisplay": "35.5%",
@@ -641,7 +652,7 @@
       "reportedAt": "2026-03-06"
     },
     {
-      "rank": 62,
+      "rank": 63,
       "systemName": "DeepMiner-32B",
       "organization": "Academic Research",
       "scoreDisplay": "33.5%",
@@ -651,7 +662,7 @@
       "reportedAt": "2025-10-09"
     },
     {
-      "rank": 63,
+      "rank": 64,
       "systemName": "Nemotron 3 Super (120B A12B)",
       "organization": "NVIDIA",
       "scoreDisplay": "31.3%",
@@ -662,7 +673,7 @@
       "reportedAt": "2026-03-11"
     },
     {
-      "rank": 64,
+      "rank": 65,
       "systemName": "DeepSeek-V3.1",
       "organization": "DeepSeek",
       "scoreDisplay": "30.0%",
@@ -673,7 +684,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 64,
+      "rank": 65,
       "systemName": "BrowseMaster",
       "organization": "Academic Research",
       "scoreDisplay": "30.0%",
@@ -683,7 +694,7 @@
       "reportedAt": "2025-08-12"
     },
     {
-      "rank": 66,
+      "rank": 67,
       "systemName": "OpenSeeker",
       "organization": "PolarSeeker",
       "scoreDisplay": "29.5%",
@@ -694,7 +705,7 @@
       "reportedAt": "2026-03-16"
     },
     {
-      "rank": 67,
+      "rank": 68,
       "systemName": "GLM-4.5",
       "organization": "Zhipu AI",
       "scoreDisplay": "26.4%",
@@ -705,7 +716,7 @@
       "reportedAt": "2025-07"
     },
     {
-      "rank": 68,
+      "rank": 69,
       "systemName": "GLM-4.5-Air",
       "organization": "Zhipu AI",
       "scoreDisplay": "21.3%",
@@ -716,7 +727,7 @@
       "reportedAt": "2025-07"
     },
     {
-      "rank": 69,
+      "rank": 70,
       "systemName": "WebExplorer-8B (RL)",
       "organization": "HKUST NLP Group",
       "scoreDisplay": "15.7%",
@@ -727,7 +738,7 @@
       "reportedAt": "2025-09-08"
     },
     {
-      "rank": 70,
+      "rank": 71,
       "systemName": "InfoAgent",
       "organization": "Academic Research",
       "scoreDisplay": "15.3%",
@@ -737,7 +748,7 @@
       "reportedAt": "2025-09-29"
     },
     {
-      "rank": 70,
+      "rank": 71,
       "systemName": "DeepDive-32B",
       "organization": "THUDM / Tsinghua University",
       "scoreDisplay": "15.3%",
@@ -748,7 +759,7 @@
       "reportedAt": "2025-09-12"
     },
     {
-      "rank": 72,
+      "rank": 73,
       "systemName": "Exa Research Pro",
       "organization": "Exa",
       "scoreDisplay": "14.0%",
@@ -758,7 +769,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 73,
+      "rank": 74,
       "systemName": "WebSailor-72B",
       "organization": "Alibaba Cloud / Tongyi Lab",
       "scoreDisplay": "12.0%",
@@ -769,7 +780,7 @@
       "reportedAt": "2025-07"
     },
     {
-      "rank": 74,
+      "rank": 75,
       "systemName": "WebSailor-32B",
       "organization": "Alibaba Cloud / Tongyi Lab",
       "scoreDisplay": "10.5%",
@@ -780,7 +791,7 @@
       "reportedAt": "2025-09-08"
     },
     {
-      "rank": 75,
+      "rank": 76,
       "systemName": "OpenAI o1",
       "organization": "OpenAI",
       "scoreDisplay": "9.9%",
@@ -790,7 +801,7 @@
       "reportedAt": "2025-04-10"
     },
     {
-      "rank": 76,
+      "rank": 77,
       "systemName": "DeepSeek-R1-0528",
       "organization": "DeepSeek",
       "scoreDisplay": "8.9%",
@@ -801,7 +812,7 @@
       "reportedAt": "2025-05-28"
     },
     {
-      "rank": 77,
+      "rank": 78,
       "systemName": "Claude Opus 4.1 (Parallel Task API benchmark)",
       "organization": "Anthropic",
       "scoreDisplay": "7.0%",
@@ -811,7 +822,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 78,
+      "rank": 79,
       "systemName": "WebSailor-7B",
       "organization": "Alibaba Cloud / Tongyi Lab",
       "scoreDisplay": "6.7%",
@@ -822,7 +833,7 @@
       "reportedAt": "2025-09-08"
     },
     {
-      "rank": 79,
+      "rank": 80,
       "systemName": "Perplexity Sonar Deep Research",
       "organization": "Perplexity",
       "scoreDisplay": "6.0%",
@@ -832,7 +843,7 @@
       "reportedAt": "2025-08"
     },
     {
-      "rank": 80,
+      "rank": 81,
       "systemName": "GPT-4o + browsing",
       "organization": "OpenAI",
       "scoreDisplay": "1.9%",
@@ -842,7 +853,7 @@
       "reportedAt": "2025-04-10"
     },
     {
-      "rank": 81,
+      "rank": 82,
       "systemName": "GPT-4.5",
       "organization": "OpenAI",
       "scoreDisplay": "0.9%",
@@ -852,7 +863,7 @@
       "reportedAt": "2025-04-10"
     },
     {
-      "rank": 82,
+      "rank": 83,
       "systemName": "GPT-4o",
       "organization": "OpenAI",
       "scoreDisplay": "0.6%",

--- a/src/data/draco.json
+++ b/src/data/draco.json
@@ -1,0 +1,137 @@
+{
+  "draco": [
+    {
+      "rank": 1,
+      "systemName": "Claude Mythos 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "86.4%",
+      "scoreValue": 86.4,
+      "sourceUrl": "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+      "notesShort": "Opus 4.6 judge; Anthropic self-eval at max adaptive-thinking effort, ~1M-token budget, no compaction, 5 grading runs. Top tracked result.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 2,
+      "systemName": "Claude Mythos Preview",
+      "organization": "Anthropic",
+      "scoreDisplay": "83.6%",
+      "scoreValue": 83.6,
+      "sourceUrl": "https://www.anthropic.com/claude-fable-5-mythos-5-system-card",
+      "notesShort": "Opus 4.6 judge; Anthropic self-eval at max adaptive-thinking effort, same protocol as the Mythos 5 row.",
+      "reportedAt": "2026-06"
+    },
+    {
+      "rank": 3,
+      "systemName": "Claude Opus 4.8",
+      "organization": "Anthropic",
+      "scoreDisplay": "80.4%",
+      "scoreValue": 80.4,
+      "sourceUrl": "https://www-cdn.anthropic.com/0f0c97ad20d8005706296bd92aa1c27c6b2f4f61/Claude%20Opus%204.8%20System%20Card.pdf",
+      "notesShort": "Opus 4.6 judge; Anthropic self-eval at max effort with a 1M-token budget and compaction at 200k, 5 grading runs. The Mythos-5 card reports 80.6% without compaction.",
+      "reportedAt": "2026-06"
+    },
+    {
+      "rank": 4,
+      "systemName": "Claude Opus 4.7",
+      "organization": "Anthropic",
+      "scoreDisplay": "77.7%",
+      "scoreValue": 77.7,
+      "sourceUrl": "https://www-cdn.anthropic.com/037f06850df7fbe871e206dad004c3db5fd50340/Claude%20Opus%204.7%20System%20Card.pdf",
+      "notesShort": "Opus 4.6 judge; Anthropic self-eval at max effort with compaction at 200k, 5 grading runs. A strict improvement over Opus 4.6 on DRACO.",
+      "reportedAt": "2026-04-16"
+    },
+    {
+      "rank": 5,
+      "systemName": "MiniMax M3",
+      "organization": "MiniMax",
+      "scoreDisplay": "73.23%",
+      "scoreValue": 73.23,
+      "sourceUrl": "https://www.minimax.io/blog/minimax-m3",
+      "notesShort": "Opus 4.6 judge; MiniMax self-eval via its internal Deep Research harness (MiniMax Code), score averaged across questions.",
+      "reportedAt": "2026-05-31",
+      "isNew": true
+    },
+    {
+      "rank": 6,
+      "systemName": "Perplexity Deep Research (Opus 4.6)",
+      "organization": "Perplexity",
+      "scoreDisplay": "70.5%",
+      "scoreValue": 70.5,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). Deep-research agent; Perplexity's own result on the benchmark it authored, top of the paper's table.",
+      "reportedAt": "2026-02-12"
+    },
+    {
+      "rank": 7,
+      "systemName": "Perplexity Deep Research (Opus 4.5)",
+      "organization": "Perplexity",
+      "scoreDisplay": "67.2%",
+      "scoreValue": 67.2,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). Older base-model variant of Perplexity Deep Research.",
+      "reportedAt": "2026-02-12"
+    },
+    {
+      "rank": 8,
+      "systemName": "Claude Fable 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "65.3%",
+      "scoreValue": 65.3,
+      "sourceUrl": "https://openrouter.ai/blog/announcements/fusion-beats-frontier/",
+      "notesShort": "OpenRouter eval, Gemini 3.1 Pro Preview judge (a third, stricter scale, not comparable to the Opus 4.6 or Gemini-3-Pro rows); top solo model in OpenRouter's panel, on 93/100 tasks (7 blocked by Fable 5 content filters).",
+      "reportedAt": "2026-06-12",
+      "isNew": true
+    },
+    {
+      "rank": 9,
+      "systemName": "Claude Opus 4.6",
+      "organization": "Anthropic",
+      "scoreDisplay": "59.8%",
+      "scoreValue": 59.8,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). Standard model + web search + code execution, not a deep-research agent; the same model that is the judge for the rows above.",
+      "reportedAt": "2026-02-12"
+    },
+    {
+      "rank": 10,
+      "systemName": "Gemini Deep Research",
+      "organization": "Google",
+      "scoreDisplay": "59.0%",
+      "scoreValue": 59.0,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). Google's deep-research agent.",
+      "reportedAt": "2026-02-12"
+    },
+    {
+      "rank": 11,
+      "systemName": "OpenAI Deep Research (o3)",
+      "organization": "OpenAI",
+      "scoreDisplay": "52.1%",
+      "scoreValue": 52.1,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). OpenAI's o3 deep-research agent.",
+      "reportedAt": "2026-02-12"
+    },
+    {
+      "rank": 12,
+      "systemName": "Claude Opus 4.5",
+      "organization": "Anthropic",
+      "scoreDisplay": "46.7%",
+      "scoreValue": 46.7,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). Standard model + web search + code execution, not a deep-research agent.",
+      "reportedAt": "2026-02-12"
+    },
+    {
+      "rank": 13,
+      "systemName": "OpenAI Deep Research (o4-mini)",
+      "organization": "OpenAI",
+      "scoreDisplay": "41.9%",
+      "scoreValue": 41.9,
+      "sourceUrl": "https://arxiv.org/abs/2602.11685",
+      "notesShort": "Gemini-3-Pro judge (paper). OpenAI's most token-efficient deep-research agent.",
+      "reportedAt": "2026-02-12"
+    }
+  ]
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -2,6 +2,7 @@ export { default as agentBench } from "./agentBench.json" with { type: "json" };
 export { default as aiderPolyglot } from "./aiderPolyglot.json" with { type: "json" };
 export { default as browsecomp } from "./browsecomp.json" with { type: "json" };
 export { default as clawbench } from "./clawbench.json" with { type: "json" };
+export { default as draco } from "./draco.json" with { type: "json" };
 export { default as gaia } from "./gaia.json" with { type: "json" };
 export { default as healthAdminBench } from "./healthAdminBench.json" with { type: "json" };
 export { default as mind2web } from "./mind2web.json" with { type: "json" };

--- a/src/data/osworld.json
+++ b/src/data/osworld.json
@@ -2,6 +2,39 @@
   "osworld": [
     {
       "rank": 1,
+      "systemName": "Claude Mythos Preview",
+      "organization": "Anthropic",
+      "scoreDisplay": "85.4%",
+      "scoreValue": 85.4,
+      "sourceUrl": "https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf",
+      "notesShort": "OSWorld-Verified pass@1 (361 tasks, 100 max steps, auto-thinking at max effort, 5-run avg) on Anthropic's revised harness; supersedes the earlier 79.6% Glasswing report. Self-reported in the Claude 5 system card.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 2,
+      "systemName": "Claude Mythos 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "85.0%",
+      "scoreValue": 85.0,
+      "sourceUrl": "https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf",
+      "notesShort": "OSWorld-Verified pass@1 (361 tasks, 100 max steps, auto-thinking at max effort, 5-run avg) on Anthropic's revised harness. Self-reported in the Claude 5 system card.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 2,
+      "systemName": "Claude Fable 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "85.0%",
+      "scoreValue": 85.0,
+      "sourceUrl": "https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf",
+      "notesShort": "Generally available sibling of Mythos 5; OSWorld-Verified pass@1 (361 tasks, 100 max steps, auto-thinking at max effort, 5-run avg). Self-reported in the Claude 5 system card.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 4,
       "systemName": "Claude Opus 4.8",
       "organization": "Anthropic",
       "scoreDisplay": "83.4%",
@@ -12,18 +45,7 @@
       "isNew": true
     },
     {
-      "rank": 2,
-      "systemName": "Mythos Preview",
-      "organization": "Anthropic",
-      "scoreDisplay": "79.6%",
-      "scoreValue": 79.6,
-      "sourceUrl": "https://www.anthropic.com/glasswing",
-      "notesShort": "Reported on Anthropic's Glasswing page.",
-      "reportedAt": "2026-04-07",
-      "isNew": true
-    },
-    {
-      "rank": 3,
+      "rank": 5,
       "systemName": "OSAgent",
       "organization": "TheAGI Company",
       "scoreDisplay": "76.26%",
@@ -33,7 +55,7 @@
       "reportedAt": "2025-10-23"
     },
     {
-      "rank": 4,
+      "rank": 6,
       "systemName": "GPT-5.4",
       "organization": "OpenAI",
       "scoreDisplay": "75.0%",
@@ -44,7 +66,7 @@
       "isNew": true
     },
     {
-      "rank": 5,
+      "rank": 7,
       "systemName": "Claude Opus 4.6",
       "organization": "Anthropic",
       "scoreDisplay": "72.7%",
@@ -54,7 +76,7 @@
       "reportedAt": "2026-02-05"
     },
     {
-      "rank": 6,
+      "rank": 8,
       "systemName": "Claude Sonnet 4.6",
       "organization": "Anthropic",
       "scoreDisplay": "72.5%",
@@ -64,7 +86,7 @@
       "reportedAt": "2026-02-17"
     },
     {
-      "rank": 7,
+      "rank": 9,
       "systemName": "Qwen3 VL 235B",
       "organization": "Alibaba",
       "scoreDisplay": "66.7%",
@@ -74,7 +96,7 @@
       "reportedAt": "2025-09-23"
     },
     {
-      "rank": 8,
+      "rank": 10,
       "systemName": "Claude Opus 4.5",
       "organization": "Anthropic",
       "scoreDisplay": "66.3%",
@@ -84,7 +106,7 @@
       "reportedAt": "2025-11-24"
     },
     {
-      "rank": 9,
+      "rank": 11,
       "systemName": "Kimi K2.5",
       "organization": "Moonshot AI",
       "scoreDisplay": "63.3%",
@@ -94,7 +116,7 @@
       "reportedAt": "2026-01-27"
     },
     {
-      "rank": 10,
+      "rank": 12,
       "systemName": "GLM-5V-Turbo",
       "organization": "Zhipu AI",
       "scoreDisplay": "62.3%",
@@ -104,7 +126,7 @@
       "reportedAt": "2026-04-01"
     },
     {
-      "rank": 11,
+      "rank": 13,
       "systemName": "Claude Sonnet 4.5",
       "organization": "Anthropic",
       "scoreDisplay": "61.4%",
@@ -114,7 +136,7 @@
       "reportedAt": "2025-09-29"
     },
     {
-      "rank": 12,
+      "rank": 14,
       "systemName": "UiPath Screen Agent",
       "organization": "UiPath",
       "scoreDisplay": "53.6%",
@@ -124,7 +146,7 @@
       "reportedAt": "2026-01-14"
     },
     {
-      "rank": 13,
+      "rank": 15,
       "systemName": "Claude Haiku 4.5",
       "organization": "Anthropic",
       "scoreDisplay": "50.7%",
@@ -134,7 +156,7 @@
       "reportedAt": "2025-10-15"
     },
     {
-      "rank": 14,
+      "rank": 16,
       "systemName": "Agent S2 + Claude 3.7",
       "organization": "Simular AI",
       "scoreDisplay": "34.5%",
@@ -144,7 +166,7 @@
       "reportedAt": "2025-03-12"
     },
     {
-      "rank": 15,
+      "rank": 17,
       "systemName": "OpenAI Operator (CUA)",
       "organization": "OpenAI",
       "scoreDisplay": "32.6%",
@@ -154,7 +176,7 @@
       "reportedAt": "2025-01-23"
     },
     {
-      "rank": 16,
+      "rank": 18,
       "systemName": "Qwen2.5 VL 72B Instruct",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "8.8%",
@@ -164,7 +186,7 @@
       "reportedAt": "2025-01-26"
     },
     {
-      "rank": 17,
+      "rank": 19,
       "systemName": "Qwen2.5 VL 32B Instruct",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "5.9%",

--- a/src/data/sweBenchVerified.json
+++ b/src/data/sweBenchVerified.json
@@ -2,7 +2,29 @@
   "sweBenchVerified": [
     {
       "rank": 1,
-      "systemName": "Claude Mythos",
+      "systemName": "Claude Mythos 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "95.5%",
+      "scoreValue": 95.5,
+      "sourceUrl": "https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf",
+      "notesShort": "Averaged over 5 trials in standard configuration (adaptive thinking at max effort, thinking blocks included in sampling). Self-reported in the Claude 5 system card.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 2,
+      "systemName": "Claude Fable 5",
+      "organization": "Anthropic",
+      "scoreDisplay": "95.0%",
+      "scoreValue": 95.0,
+      "sourceUrl": "https://www-cdn.anthropic.com/d00db56fa754a1b115b6dd7cb2e3c342ee809620.pdf",
+      "notesShort": "Generally available sibling of Mythos 5; averaged over 5 trials in standard configuration. Self-reported in the Claude 5 system card.",
+      "reportedAt": "2026-06",
+      "isNew": true
+    },
+    {
+      "rank": 3,
+      "systemName": "Claude Mythos Preview",
       "organization": "Anthropic",
       "scoreDisplay": "93.9%",
       "scoreValue": 93.9,
@@ -11,7 +33,7 @@
       "reportedAt": "2026-04-09"
     },
     {
-      "rank": 2,
+      "rank": 4,
       "systemName": "Claude Opus 4.8",
       "organization": "Anthropic",
       "scoreDisplay": "88.6%",
@@ -22,7 +44,7 @@
       "isNew": true
     },
     {
-      "rank": 3,
+      "rank": 5,
       "systemName": "Claude Opus 4.7",
       "organization": "Anthropic",
       "scoreDisplay": "87.6%",
@@ -32,7 +54,7 @@
       "reportedAt": "2026-04-16"
     },
     {
-      "rank": 4,
+      "rank": 6,
       "systemName": "Claude Opus 4.5",
       "organization": "Anthropic",
       "scoreDisplay": "80.9%",
@@ -42,7 +64,7 @@
       "reportedAt": "2025-11-24"
     },
     {
-      "rank": 5,
+      "rank": 7,
       "systemName": "Claude Opus 4.6",
       "organization": "Anthropic",
       "scoreDisplay": "80.8%",
@@ -52,7 +74,7 @@
       "reportedAt": "2026-02-05"
     },
     {
-      "rank": 6,
+      "rank": 8,
       "systemName": "DeepSeek-V4-Pro-Max",
       "organization": "DeepSeek",
       "scoreDisplay": "80.6%",
@@ -63,7 +85,7 @@
       "isNew": true
     },
     {
-      "rank": 6,
+      "rank": 8,
       "systemName": "Gemini 3.1 Pro",
       "organization": "Google DeepMind",
       "scoreDisplay": "80.6%",
@@ -73,7 +95,7 @@
       "reportedAt": "2026-02-19"
     },
     {
-      "rank": 8,
+      "rank": 10,
       "systemName": "Kimi K2.6",
       "organization": "Moonshot AI",
       "scoreDisplay": "80.2%",
@@ -84,7 +106,7 @@
       "isNew": true
     },
     {
-      "rank": 8,
+      "rank": 10,
       "systemName": "MiniMax M2.5",
       "organization": "MiniMax",
       "scoreDisplay": "80.2%",
@@ -94,7 +116,7 @@
       "reportedAt": "2026-02-12"
     },
     {
-      "rank": 10,
+      "rank": 12,
       "systemName": "GPT-5.2",
       "organization": "OpenAI",
       "scoreDisplay": "80.0%",
@@ -104,7 +126,7 @@
       "reportedAt": "2025-12-11"
     },
     {
-      "rank": 11,
+      "rank": 13,
       "systemName": "Claude Sonnet 4.6",
       "organization": "Anthropic",
       "scoreDisplay": "79.6%",
@@ -114,7 +136,7 @@
       "reportedAt": "2026-02-17"
     },
     {
-      "rank": 12,
+      "rank": 14,
       "systemName": "DeepSeek-V4-Flash-Max",
       "organization": "DeepSeek",
       "scoreDisplay": "79.0%",
@@ -124,7 +146,7 @@
       "reportedAt": "2026-04-24"
     },
     {
-      "rank": 13,
+      "rank": 15,
       "systemName": "Qwen3.6 Plus",
       "organization": "Alibaba Cloud / Qwen Team",
       "scoreDisplay": "78.8%",
@@ -134,7 +156,7 @@
       "reportedAt": "2026-04-02"
     },
     {
-      "rank": 14,
+      "rank": 16,
       "systemName": "Gemini 3 Flash",
       "organization": "Google DeepMind",
       "scoreDisplay": "78.0%",
@@ -144,7 +166,7 @@
       "reportedAt": "2025-12-17"
     },
     {
-      "rank": 14,
+      "rank": 16,
       "systemName": "MiMo-V2-Pro",
       "organization": "Xiaomi",
       "scoreDisplay": "78.0%",
@@ -154,7 +176,7 @@
       "reportedAt": "2026-03-18"
     },
     {
-      "rank": 16,
+      "rank": 18,
       "systemName": "GLM-5",
       "organization": "Zhipu AI",
       "scoreDisplay": "77.8%",

--- a/src/lib/benchmark-hub.ts
+++ b/src/lib/benchmark-hub.ts
@@ -3,6 +3,7 @@ import {
   aiderPolyglot,
   browsecomp,
   clawbench,
+  draco,
   gaia,
   healthAdminBench,
   mind2web,
@@ -18,6 +19,7 @@ type BenchmarkMap = {
   aiderPolyglot: Record<string, BenchmarkResultRow[]>;
   browsecomp: Record<string, BenchmarkResultRow[]>;
   clawbench: Record<string, BenchmarkResultRow[]>;
+  draco: Record<string, BenchmarkResultRow[]>;
   gaia: Record<string, BenchmarkResultRow[]>;
   healthAdminBench: Record<string, BenchmarkResultRow[]>;
   mind2web: Record<string, BenchmarkResultRow[]>;
@@ -33,6 +35,7 @@ const benchmarkMap: BenchmarkMap = {
   aiderPolyglot,
   browsecomp,
   clawbench,
+  draco,
   gaia,
   healthAdminBench,
   mind2web,
@@ -292,10 +295,89 @@ export const benchmarkPages: BenchmarkPageData[] = [
         },
         { label: "simple-evals repository", url: "https://github.com/openai/simple-evals" },
       ],
-      relatedBenchmarks: ["gaia", "webvoyager", "online-mind2web"],
+      relatedBenchmarks: ["draco", "gaia", "webvoyager", "online-mind2web"],
       lastUpdated: "2026-05-28",
     },
     results: benchmarkResults("browsecomp") ?? [],
+  },
+  {
+    meta: {
+      slug: "draco",
+      name: "DRACO",
+      description:
+        "DRACO leaderboard for deep research systems on Perplexity's benchmark: 100 expert-graded research tasks across 10 domains, with sourced scores and notes on the grading judge.",
+      categoryLabel: "Deep Research Agent",
+      seoHook:
+        "deep research systems on 100 production-sourced, expert-graded research report tasks",
+      category: "research_search",
+      scope: "mixed",
+      about: [
+        "DRACO (Deep Research Accuracy, Completeness, and Objectivity) is Perplexity's benchmark for deep research systems: 100 open-ended tasks across 10 domains, sourced from real Perplexity Deep Research traffic and graded against expert rubrics on accuracy, completeness, presentation, and citation.",
+        "Unlike short-answer benchmarks such as BrowseComp, DRACO grades full research reports, so it rewards synthesis, citation quality, and presentation, not just finding the answer. It is the closest public measure of how well a system writes a real research report.",
+        "Read each row as a whole system: the agent or harness, the base model, and the grading judge all shape the number. Here the judge matters most, so the methodology is part of the ranking, not a footnote.",
+      ],
+      methodology: [
+        "The headline metric is the normalized score (0–100%): each rubric criterion gets a binary MET/UNMET verdict from an LLM judge, aggregated by weight into a per-task score and averaged across 100 tasks. An unweighted pass rate is a secondary metric.",
+        "The judge is the dominant variable. The paper used Gemini-3-Pro (now unavailable); Anthropic finds that swapping judges shifts absolute scores 10–25 points while preserving order. Three judges appear here: Claude Opus 4.6 (Anthropic, MiniMax), Gemini 3.1 Pro Preview (OpenRouter's Fable 5 row), and Gemini-3-Pro (the paper). Compare only within the same judge.",
+        "Rows are vendor self-evaluations under a shared judge. Anthropic grades its own models at max effort with a ~1M-token budget, compaction, and five grading runs of the final report; MiniMax grades M3 through its internal harness. Treat each as self-reported.",
+        "Each judge is a separate ladder, so don't compare rank gaps across them. The same model shows it: Opus 4.8 scores 80.4% under Anthropic's Opus 4.6 judge and 58.8% under OpenRouter's Gemini 3.1 Pro Preview judge.",
+      ],
+      taskExamples: [
+        {
+          quote:
+            'In 2008, Longwood Gardens opened "Nature\'s Castles: The Treehouse Reimagined" featuring three treehouse structures. Can you find the name of the architectural firm or designer who created these treehouses, and locate a contemporaneous source (2008 or earlier) that describes the design concept and construction process?',
+          sourceLabel: "DRACO paper, augmented task example",
+          sourceUrl: "https://arxiv.org/abs/2602.11685",
+        },
+        {
+          quote:
+            "Define an independent director under the NASDAQ listing standards. List the eligibility criteria (who qualifies) and disqualification criteria (who cannot serve). Which types of companies are required to have independent directors on their board?",
+          sourceLabel: "DRACO paper, augmented task example",
+          sourceUrl: "https://arxiv.org/abs/2602.11685",
+        },
+        {
+          quote:
+            "Document the global expansion and local resistance to industrial agriculture mega-farms, comparing case studies from Ukraine's massive grain operations, Brazilian cerrado soy plantations, Saudi Arabia's desert farming investments in Arizona and California, and Chinese pork production facilities.",
+          sourceLabel: "DRACO paper, augmented task example",
+          sourceUrl: "https://arxiv.org/abs/2602.11685",
+        },
+      ],
+      importantNotes: [
+        "Three judges, one table. Rows are graded by Claude Opus 4.6 (Anthropic, MiniMax), Gemini 3.1 Pro Preview (OpenRouter), or Gemini-3-Pro (the paper). Judge methodology varies, and judge choice shifts absolute scores 10–25 points, so read each row's note before comparing.",
+        "Vendor self-reported under a common judge. The top rows are Anthropic models graded by an Anthropic judge, and DRACO was authored by Perplexity, so each regime favors its originator. Expect levels to move as more evaluators adopt the Opus 4.6 judge.",
+        "Mixed scope: rows mix full deep-research agents (Perplexity, MiniMax) with standard models plus tools (Claude Opus 4.6 and 4.5 in the paper). Compare within a setup class before reading a rank gap as capability.",
+      ],
+      links: [
+        { label: "DRACO paper", url: "https://arxiv.org/abs/2602.11685" },
+        {
+          label: "DRACO dataset (Hugging Face)",
+          url: "https://hf.co/datasets/perplexity-ai/draco",
+        },
+        {
+          label: "Perplexity DRACO research article",
+          url: "https://research.perplexity.ai/articles/evaluating-deep-research-performance-in-the-wild-with-the-draco-benchmark",
+        },
+        {
+          label: "Claude Opus 4.8 System Card (DRACO section)",
+          url: "https://www-cdn.anthropic.com/0f0c97ad20d8005706296bd92aa1c27c6b2f4f61/Claude%20Opus%204.8%20System%20Card.pdf",
+        },
+        {
+          label: "Claude Opus 4.7 System Card (DRACO section)",
+          url: "https://www-cdn.anthropic.com/037f06850df7fbe871e206dad004c3db5fd50340/Claude%20Opus%204.7%20System%20Card.pdf",
+        },
+        {
+          label: "MiniMax M3 launch post",
+          url: "https://www.minimax.io/blog/minimax-m3",
+        },
+        {
+          label: "OpenRouter Fusion DRACO evaluation",
+          url: "https://openrouter.ai/blog/announcements/fusion-beats-frontier/",
+        },
+      ],
+      relatedBenchmarks: ["browsecomp", "gaia", "online-mind2web"],
+      lastUpdated: "2026-06-23",
+    },
+    results: benchmarkResults("draco") ?? [],
   },
   {
     meta: {
@@ -603,7 +685,7 @@ export const benchmarkPages: BenchmarkPageData[] = [
           url: "https://huggingface.co/spaces/gaia-benchmark/leaderboard",
         },
       ],
-      relatedBenchmarks: ["browsecomp", "agentbench", "tau-bench"],
+      relatedBenchmarks: ["browsecomp", "draco", "agentbench", "tau-bench"],
       lastUpdated: "2026-04-16",
     },
     results: benchmarkResults("gaia") ?? [],

--- a/src/pages/leaderboards/[slug].astro
+++ b/src/pages/leaderboards/[slug].astro
@@ -140,15 +140,15 @@ const breadcrumbSchema = JSON.stringify({
         <h2 class="m-0 text-xl font-medium tracking-[-0.03em] text-[var(--color-text-strong)]">
           About this benchmark
         </h2>
-        <div class="mt-4 space-y-4">
-          {page.meta.about.map((paragraph) => <p class="m-0">{paragraph}</p>)}
+        <div class="mt-4">
+          {page.meta.about.map((paragraph) => <p class="mb-4 last:mb-0">{paragraph}</p>)}
         </div>
 
         {
           page.meta.importantNotes.length > 0 && (
             <div class="dashed-frame mt-5 p-4">
               {page.meta.importantNotes.map((note) => (
-                <p class="m-0 text-sm muted">{note}</p>
+                <p class="mb-3 text-sm muted last:mb-0">{note}</p>
               ))}
             </div>
           )


### PR DESCRIPTION
Adds the **DRACO** deep research benchmark leaderboard.

**13 rows across three grading-judge regimes**, each row's note declaring its judge and the methodology explaining scores aren't comparable across judges:
- **Opus 4.6 judge**: Mythos 5 (86.4), Mythos Preview (83.6), Opus 4.8 (80.4), Opus 4.7 (77.7), MiniMax M3 (73.23)
- **Gemini 3.1 Pro Preview judge** (OpenRouter): Fable 5 (65.3, 93/100 tasks)
- **Gemini-3-Pro judge** (original paper): Perplexity DR (70.5/67.2), Opus 4.6 (59.8), Gemini DR (59.0), o3 (52.1), Opus 4.5 (46.7), o4-mini (41.9)

**Sources**: arXiv:2602.11685, Fable 5/Mythos 5 system card, Opus 4.7 & 4.8 system cards, MiniMax M3 launch post, OpenRouter Fusion eval.

**Also fixes** glued paragraph spacing in the shared `[slug].astro` template — `m-0` on the about/notes `<p>`s was canceling `space-y-*` (equal specificity), so every benchmark page's about section rendered flush. Spacing moved onto the `<p>` (`mb-4 last:mb-0` / `mb-3 last:mb-0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)